### PR TITLE
Add Commander Anthology Volume II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+/decks.json

--- a/data/cmd/cm2/Breed Lethality.txt
+++ b/data/cmd/cm2/Breed Lethality.txt
@@ -1,0 +1,87 @@
+// NAME: Breed Lethality
+// COMMENTS: https://magic.wizards.com/en/products/Commander-Anthology-2
+1 Thrummingbird
+1 Festercreep
+1 Scavenging Ooze
+1 Abzan Falconer
+1 Orzhov Advokist
+1 Tuskguard Captain
+1 Necroplasm
+1 Champion of Lambholt
+1 Reyhan, Last of the Abzan [foil]
+1 Vorel of the Hull Clade
+1 Crystalline Crawler
+1 Custodi Soulbinders
+1 Forgotten Ancient
+1 Bane of the Living
+1 Ishai, Ojutai Dragonspeaker [foil]
+1 Corpsejack Menace
+1 Fathom Mage
+1 Master Biomancer
+1 Elite Scaleguard
+1 Reveillark
+1 Deepglow Skate
+1 Kalonian Hydra
+1 Ikra Shidiqi, the Usurper [foil]
+1 Vulturous Zombie
+1 Juniper Order Ranger
+1 Ghave, Guru of Spores
+1 Enduring Scalelord
+1 Manifold Insights
+1 Languish
+1 Tezzeret's Gambit
+1 Migratory Route
+1 Merciless Eviction
+1 Spitting Image
+1 Sublime Exhalation
+1 Duneblast
+1 Treasure Cruise
+1 Disdainful Stroke
+1 Solidarity of Heroes
+1 Grip of Phyresis
+1 Inspiring Call
+1 Mortify
+1 Putrefy
+1 Ancient Excavation
+1 Mirrorweave
+1 Sylvan Reclamation
+1 Sol Ring
+1 Fellwar Stone
+1 Golgari Signet
+1 Orzhov Signet
+1 Simic Signet
+1 Commander's Sphere
+1 Darksteel Ingot
+1 Cauldron of Souls
+1 Astral Cornucopia
+1 Hardened Scales
+1 Brave the Sands
+1 Duelist's Heritage
+1 Bred for the Hunt
+1 Citadel Siege
+1 Cathars' Crusade
+1 Arcane Sanctum
+1 Ash Barrens
+1 Azorius Chancery
+1 Command Tower
+1 Darkwater Catacombs
+1 Dreadship Reef
+1 Evolving Wilds
+1 Exotic Orchard
+1 Golgari Rot Farm
+1 Murmuring Bosk
+1 Opal Palace
+1 Opulent Palace
+1 Sandsteppe Citadel
+1 Seaside Citadel
+1 Sungrass Prairie
+1 Temple of the False God
+1 Terramorphic Expanse
+1 Underground River
+5 Plains
+4 Island
+5 Swamp
+7 Forest
+
+Sideboard
+1 Atraxa, Praetors' Voice [foil]

--- a/data/cmd/cm2/Built From Scratch.txt
+++ b/data/cmd/cm2/Built From Scratch.txt
@@ -1,0 +1,76 @@
+// NAME: Built From Scratch
+// COMMENTS: https://magic.wizards.com/en/products/Commander-Anthology-2
+1 Goblin Welder
+1 Epochrasite
+1 Myr Retriever
+1 Myr Sire
+1 Bottle Gnomes
+1 Cathodion
+1 Junk Diver
+1 Palladium Myr
+1 Pilgrim's Eye
+1 Tuktuk the Explorer
+1 Dualcaster Mage
+1 Feldon of the Third Path [foil]
+1 Solemn Simulacrum
+1 Flametongue Kavu
+1 Beetleback Chief
+1 Ingot Chewer
+1 Steel Hellkite
+1 Wurmcoil Engine
+1 Spitebellows
+1 Hoard-Smelter Dragon
+1 Warmonger Hellkite
+1 Myr Battlesphere
+1 Pentavus
+1 Tyrant's Familiar
+1 Bosh, Iron Golem [foil]
+1 Bogardan Hellkite
+1 Faithless Looting
+1 Whipflare
+1 Scrap Mastery
+1 Incite Rebellion
+1 Blasphemous Act
+1 Impact Resonance
+1 Chaos Warp
+1 Volcanic Offering
+1 Word of Seizing
+1 Magmaquake
+1 Starstorm
+1 Everflowing Chalice
+1 Panic Spellbomb
+1 Sol Ring
+1 Wayfarer's Bauble
+1 Fire Diamond
+1 Ichor Wellspring
+1 Liquimetal Coating
+1 Mind Stone
+1 Mycosynth Wellspring
+1 Ruby Medallion
+1 Swiftfoot Boots
+1 Commander's Sphere
+1 Jalum Tome
+1 Pristine Talisman
+1 Unstable Obelisk
+1 Trading Post
+1 Caged Sun
+1 Dreamstone Hedron
+1 Loreseeker's Stone
+1 Spine of Ish Sah
+1 Darksteel Citadel
+1 Great Furnace
+1 Bitter Feud
+1 Arcane Lighthouse
+1 Buried Ruin
+1 Dormant Volcano
+1 Flamekin Village
+1 Forgotten Cave
+1 Ghost Quarter
+1 Phyrexia's Core
+1 Reliquary Tower
+1 Smoldering Crater
+1 Temple of the False God
+29 Mountain
+
+Sideboard
+1 Daretti, Scrap Savant [foil]

--- a/data/cmd/cm2/Devour for Power.txt
+++ b/data/cmd/cm2/Devour for Power.txt
@@ -1,0 +1,80 @@
+// NAME: Devour for Power
+// COMMENTS: https://magic.wizards.com/en/products/Commander-Anthology-2
+1 Nezumi Graverobber
+1 Skullbriar, the Walking Grave
+1 Riddlekeeper
+1 Fleshbag Marauder
+1 Eternal Witness
+1 Troll Ascetic
+1 Yavimaya Elder
+1 Solemn Simulacrum
+1 Brawn
+1 Wonder
+1 Sewer Nemesis
+1 Gravedigger
+1 Lhurgoyf
+1 Dreamborn Muse
+1 Mortivore
+1 Desecrator Hag
+1 Mulldrifter
+1 Acidic Slime
+1 Vulturous Zombie
+1 Dark Hatchling
+1 Extractor Demon
+1 Scythe Specter
+1 Wrexial, the Risen Deep
+1 Vorosh, the Hunter [foil]
+1 Triskelavus
+1 Slipstream Eel
+1 Butcher of Malakir
+1 Patron of the Nezumi
+1 Damia, Sage of Stone [foil]
+1 Szadek, Lord of Secrets
+1 Avatar of Woe
+1 Artisan of Kozilek
+1 Minds Aglow
+1 Shared Trauma
+1 Sign in Blood
+1 Stitch Together
+1 Cultivate
+1 Windfall
+1 Buried Alive
+1 Syphon Mind
+1 Unnerve
+1 Rise from the Grave
+1 Syphon Flesh
+1 Living Death
+1 Tribute to the Wild
+1 Spell Crumple
+1 Fact or Fiction
+1 Relic Crush
+1 Sol Ring
+1 Dimir Signet
+1 Golgari Signet
+1 Lightning Greaves
+1 Simic Signet
+1 Oblivion Stone
+1 Vow of Wildness
+1 Vow of Flight
+1 Vow of Malice
+1 Memory Erosion
+1 Grave Pact
+1 Barren Moor
+1 Command Tower
+1 Dimir Aqueduct
+1 Dreadship Reef
+1 Golgari Rot Farm
+1 Jwar Isle Refuge
+1 Lonely Sandbar
+1 Rupture Spire
+1 Simic Growth Chamber
+1 Svogthos, the Restless Tomb
+1 Temple of the False God
+1 Terramorphic Expanse
+1 Tranquil Thicket
+8 Forest
+8 Island
+11 Swamp
+
+Sideboard
+1 The Mimeoplasm [foil]

--- a/data/cmd/cm2/Wade into Battle.txt
+++ b/data/cmd/cm2/Wade into Battle.txt
@@ -1,0 +1,81 @@
+// NAME: Wade into Battle
+// COMMENTS: https://magic.wizards.com/en/products/Commander-Anthology-2
+1 Oreskos Explorer
+1 Magus of the Wheel
+1 Stinkdrinker Daredevil
+1 Taurean Mauler
+1 Dawnglare Invoker
+1 Desolation Giant
+1 Fumiko the Lowblood
+1 Hunted Dragon
+1 Stoneshock Giant
+1 Thundercloud Shaman
+1 Warchief Giant
+1 Herald of the Host
+1 Kalemne's Captain
+1 Anya, Merciless Angel [foil]
+1 Sunrise Sovereign
+1 Hammerfist Giant
+1 Inferno Titan
+1 Dawnbreak Reclaimer
+1 Sun Titan
+1 Hostility
+1 Jareth, Leonine Titan
+1 Victory's Herald
+1 Sandstone Oracle
+1 Hamletback Goliath
+1 Arbiter of Knollridge
+1 Borderland Behemoth
+1 Dream Pillager
+1 Magma Giant
+1 Angel of Serenity
+1 Gisela, Blade of Goldnight [foil]
+1 Breath of Darigaaz
+1 Fiery Confluence
+1 Disaster Radius
+1 Earthquake
+1 Meteor Blast
+1 Fall of the Hammer
+1 Orim's Thunder
+1 Sol Ring
+1 Blade of Selves
+1 Boros Signet
+1 Coldsteel Heart
+1 Fellwar Stone
+1 Lightning Greaves
+1 Mind Stone
+1 Thought Vessel
+1 Basalt Monolith
+1 Boros Cluestone
+1 Darksteel Ingot
+1 Loxodon Warhammer
+1 Urza's Incubator
+1 Worn Powerstone
+1 Seer's Sundial
+1 Dreamstone Hedron
+1 Staff of Nin
+1 Curse of the Nightly Hunt
+1 Banishing Light
+1 Faith's Fetters
+1 Rite of the Raging Storm
+1 Warstorm Surge
+1 Ancient Amphitheater
+1 Blasted Landscape
+1 Boros Garrison
+1 Boros Guildgate
+1 Command Tower
+1 Drifting Meadow
+1 Evolving Wilds
+1 Forgotten Cave
+1 Secluded Steppe
+1 Smoldering Crater
+1 Terramorphic Expanse
+1 Vivid Crag
+1 Vivid Meadow
+1 Wind-Scarred Crag
+14 Mountain
+11 Plains
+1 Crib Swap
+
+Sideboard
+1 Kalemne, Disciple of Iroas [foil]

--- a/lib/sets.rb
+++ b/lib/sets.rb
@@ -218,4 +218,5 @@ MagicSets = {
   "ddt"=>"Duel Decks: Merfolk vs. Goblins",
   "ddu"=>"Duel Decks: Elves vs. Inventors",
   "dom"=>"Dominaria",
+  "cm2"=>"Commander Anthology Volume II",
 }


### PR DESCRIPTION
This adds the decklists for CM2, including foil information sourced from [this unboxing video](https://www.youtube.com/watch?v=n3QjGzXWsd4).

I've also added `decks.json` to the gitignore, since it's generated by the validation but not in the repo.