### PR TITLE
Updated misspelled Jumpstart deck

### DIFF
--- a/data/jumpstart/jmp/Spellcasting (1).txt
+++ b/data/jumpstart/jmp/Spellcasting (1).txt
@@ -1,4 +1,4 @@
-// NAME: Spellingcasting (1)
+// NAME: Spellcasting (1)
 // COMMENTS: https://magic.wizards.com/en/articles/archive/feature/jumpstart-decklists-2020-06-18
 // DATE: 2020-07-17
 1 Thermo-Alchemist


### PR DESCRIPTION
"Spellcasting (1)" Jumpstart deck was misspelled as "Spellingcasting (1)" in both the filename and in the txt file itself. Fixed this typo.

Not sure if there are any other references that need to be updated.