### PR TITLE
Updated OGW Intro Pack decklists with the specific versions of Wastes

### DIFF
--- a/data/intro/ogw/Twisted Reality.txt
+++ b/data/intro/ogw/Twisted Reality.txt
@@ -24,7 +24,8 @@
 1 Scour from Existence
 1 Blighted Cataract
 1 Evolving Wilds
-10 Wastes
+5 Wastes [OGW:183a]
+5 Wastes [OGW:184a]
 14 Island
 
 Sideboard

--- a/data/intro/ogw/Vicious Cycle.txt
+++ b/data/intro/ogw/Vicious Cycle.txt
@@ -28,7 +28,8 @@
 1 Blighted Woodland
 1 Evolving Wilds
 2 Fertile Thicket
-4 Wastes
+2 Wastes [OGW:183a]
+2 Wastes [OGW:184a]
 8 Swamp
 9 Forest
 


### PR DESCRIPTION
Updated OGW Intro Packs with specific versions of Wastes along with counts for each.

The Wastes in the OGW Intro Packs are different than the ones in OGW Booster Packs. The Wastes in Booster Packs are full art, the ones in the Intro Packs are regular art and are exclusive to these decks making them more desirable. There are 2 different arts and there appears to be an equal distribution in each deck with half of the wastes being one art, half the other.

Here are openings on YouTube that I used for proof:
https://youtu.be/uy_3tKXQ8Mk?t=197
https://youtu.be/KrF5BZ5rFaA?t=226
