### PR TITLE
Fix 40k deck printings

### DIFF
--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -20,7 +20,7 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Talisman of Dominance [40K:254]
 1 Talisman of Hierarchy
 1 Talisman of Progress
-1 Arcane Signet
+1 Arcane Signet [40K:229]
 1 Commander's Sphere [40K:233]
 1 Reconnaissance Mission
 1 Choked Estuary

--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -40,8 +40,8 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Scoured Barrens
 1 Terramorphic Expanse
 1 Tranquil Cove
-5 Island
-7 Swamp
+5 Island [40K:307]
+7 Swamp [40K:314]
 8 Plains
 1 Marneus Calgar [40K:175] [foil]
 1 Celestine, the Living Saint

--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -17,7 +17,7 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Mind Stone [40K:244]
 1 Skullclamp
 1 Sol Ring [40K:251]
-1 Talisman of Dominance
+1 Talisman of Dominance [40K:254]
 1 Talisman of Hierarchy
 1 Talisman of Progress
 1 Arcane Signet

--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -33,7 +33,7 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Arcane Sanctum
 1 Ash Barrens
 1 Memorial to Glory
-1 Command Tower
+1 Command Tower [40K:272]
 1 Dismal Backwater
 1 Evolving Wilds
 1 Path of Ancestry

--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -21,7 +21,7 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Talisman of Hierarchy
 1 Talisman of Progress
 1 Arcane Signet
-1 Commander's Sphere
+1 Commander's Sphere [40K:233]
 1 Reconnaissance Mission
 1 Choked Estuary
 1 Darkwater Catacombs

--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -1,7 +1,7 @@
 // NAME: Forces of the Imperium
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 Inquisitor Greyfax [foil]
+COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Bastion Protector
 1 Collective Effort
 1 Deploy to the Front
@@ -43,7 +43,7 @@ COMMANDER: 1 Inquisitor Greyfax [foil]
 5 Island
 7 Swamp
 8 Plains
-1 Marneus Calgar [foil]
+1 Marneus Calgar [40K:175] [foil]
 1 Celestine, the Living Saint
 1 Defenders of Humanity
 1 For the Emperor!

--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -14,7 +14,7 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Swords to Plowshares
 1 Mortify
 1 Everflowing Chalice
-1 Mind Stone
+1 Mind Stone [40K:244]
 1 Skullclamp
 1 Sol Ring [40K:251]
 1 Talisman of Dominance

--- a/data/cmd/40k/Necron Dynasties.txt
+++ b/data/cmd/40k/Necron Dynasties.txt
@@ -30,7 +30,9 @@ COMMANDER: 1 Szarekh, the Silent King [40K:170] [foil]
 1 Desert of the Glorified
 1 Polluted Mire
 1 Vault of Whispers
-30 Swamp
+10 Swamp [40K:310]
+10 Swamp [40K:312]
+10 Swamp [40K:313]
 1 Imotekh the Stormlord [40K:169] [foil]
 1 Anrakyr the Traveller
 1 Biotransference

--- a/data/cmd/40k/Necron Dynasties.txt
+++ b/data/cmd/40k/Necron Dynasties.txt
@@ -23,7 +23,7 @@ COMMANDER: 1 Szarekh, the Silent King [40K:170] [foil]
 1 Mind Stone [40K:245]
 1 Thought Vessel
 1 Unstable Obelisk
-1 Wayfarer's Bauble
+1 Wayfarer's Bauble [40K:262]
 1 Barren Moor
 1 Myriad Landscape
 1 Reliquary Tower

--- a/data/cmd/40k/Necron Dynasties.txt
+++ b/data/cmd/40k/Necron Dynasties.txt
@@ -19,7 +19,7 @@ COMMANDER: 1 Szarekh, the Silent King [40K:170] [foil]
 1 Mask of Memory
 1 Sol Ring [40K:252]
 1 Arcane Signet
-1 Commander's Sphere
+1 Commander's Sphere [40K:234]
 1 Mind Stone [40K:245]
 1 Thought Vessel
 1 Unstable Obelisk

--- a/data/cmd/40k/Necron Dynasties.txt
+++ b/data/cmd/40k/Necron Dynasties.txt
@@ -1,7 +1,7 @@
 // NAME: Necron Dynasties
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 Szarekh, the Silent King [foil]
+COMMANDER: 1 Szarekh, the Silent King [40K:170] [foil]
 1 Beacon of Unrest
 1 Living Death
 1 Mutilate
@@ -31,7 +31,7 @@ COMMANDER: 1 Szarekh, the Silent King [foil]
 1 Polluted Mire
 1 Vault of Whispers
 30 Swamp
-1 Imotekh the Stormlord [foil]
+1 Imotekh the Stormlord [40K:169] [foil]
 1 Anrakyr the Traveller
 1 Biotransference
 1 Chronomancer

--- a/data/cmd/40k/Necron Dynasties.txt
+++ b/data/cmd/40k/Necron Dynasties.txt
@@ -18,7 +18,7 @@ COMMANDER: 1 Szarekh, the Silent King [40K:170] [foil]
 1 Hedron Archive
 1 Mask of Memory
 1 Sol Ring [40K:252]
-1 Arcane Signet
+1 Arcane Signet [40K:228]
 1 Commander's Sphere [40K:234]
 1 Mind Stone [40K:245]
 1 Thought Vessel

--- a/data/cmd/40k/Necron Dynasties.txt
+++ b/data/cmd/40k/Necron Dynasties.txt
@@ -20,7 +20,7 @@ COMMANDER: 1 Szarekh, the Silent King [40K:170] [foil]
 1 Sol Ring [40K:252]
 1 Arcane Signet
 1 Commander's Sphere
-1 Mind Stone
+1 Mind Stone [40K:245]
 1 Thought Vessel
 1 Unstable Obelisk
 1 Wayfarer's Bauble

--- a/data/cmd/40k/The Ruinous Powers.txt
+++ b/data/cmd/40k/The Ruinous Powers.txt
@@ -20,7 +20,7 @@ COMMANDER: 1 Abaddon the Despoiler [40K:171] [foil]
 1 Talisman of Indulgence
 1 Worn Powerstone
 1 Commander's Sphere [40K:235]
-1 Wayfarer's Bauble
+1 Wayfarer's Bauble [40K:261]
 1 Warstorm Surge
 1 Exotic Orchard
 1 Foreboding Ruins

--- a/data/cmd/40k/The Ruinous Powers.txt
+++ b/data/cmd/40k/The Ruinous Powers.txt
@@ -19,7 +19,7 @@ COMMANDER: 1 Abaddon the Despoiler [40K:171] [foil]
 1 Talisman of Dominance
 1 Talisman of Indulgence
 1 Worn Powerstone
-1 Commander's Sphere
+1 Commander's Sphere [40K:235]
 1 Wayfarer's Bauble
 1 Warstorm Surge
 1 Exotic Orchard

--- a/data/cmd/40k/The Ruinous Powers.txt
+++ b/data/cmd/40k/The Ruinous Powers.txt
@@ -1,7 +1,7 @@
 // NAME: The Ruinous Powers
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 Abaddon the Despoiler [foil]
+COMMANDER: 1 Abaddon the Despoiler [40K:171] [foil]
 1 Past in Flames
 1 Decree of Pain
 1 Blasphemous Act
@@ -39,7 +39,7 @@ COMMANDER: 1 Abaddon the Despoiler [foil]
 8 Mountain
 8 Swamp
 8 Island
-1 Be'lakor, the Dark Master [foil]
+1 Be'lakor, the Dark Master [40K:172] [foil]
 1 Lord of Change
 1 Blight Grenade
 1 Great Unclean One

--- a/data/cmd/40k/The Ruinous Powers.txt
+++ b/data/cmd/40k/The Ruinous Powers.txt
@@ -36,9 +36,9 @@ COMMANDER: 1 Abaddon the Despoiler [40K:171] [foil]
 1 Path of Ancestry
 1 Swiftwater Cliffs
 1 Terramorphic Expanse
-8 Mountain
-8 Swamp
-8 Island
+8 Mountain [40K:316]
+8 Swamp [40K:311]
+8 Island [40K:308]
 1 Be'lakor, the Dark Master [40K:172] [foil]
 1 Lord of Change
 1 Blight Grenade

--- a/data/cmd/40k/The Ruinous Powers.txt
+++ b/data/cmd/40k/The Ruinous Powers.txt
@@ -16,7 +16,7 @@ COMMANDER: 1 Abaddon the Despoiler [40K:171] [foil]
 1 Assault Suit
 1 Sol Ring [40K:250]
 1 Talisman of Creativity
-1 Talisman of Dominance
+1 Talisman of Dominance [40K:255]
 1 Talisman of Indulgence
 1 Worn Powerstone
 1 Commander's Sphere [40K:235]

--- a/data/cmd/40k/The Ruinous Powers.txt
+++ b/data/cmd/40k/The Ruinous Powers.txt
@@ -29,7 +29,7 @@ COMMANDER: 1 Abaddon the Despoiler [40K:171] [foil]
 1 Crumbling Necropolis
 1 Molten Slagheap
 1 Temple of the False God
-1 Command Tower
+1 Command Tower [40K:271]
 1 Dismal Backwater
 1 Evolving Wilds
 1 Forgotten Cave

--- a/data/cmd/40k/Tyranid Swarm.txt
+++ b/data/cmd/40k/Tyranid Swarm.txt
@@ -31,7 +31,7 @@ COMMANDER: 1 The Swarmlord [40K:176] [foil]
 1 Frontier Bivouac
 1 Unclaimed Territory
 1 Cave of Temptation
-1 Command Tower
+1 Command Tower [40K:270]
 1 Evolving Wilds
 1 Opal Palace
 1 Path of Ancestry

--- a/data/cmd/40k/Tyranid Swarm.txt
+++ b/data/cmd/40k/Tyranid Swarm.txt
@@ -1,7 +1,7 @@
 // NAME: Tyranid Swarm
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 The Swarmlord [foil]
+COMMANDER: 1 The Swarmlord [40K:176] [foil]
 1 Hull Breach
 1 Cultivate
 1 Explore
@@ -41,7 +41,7 @@ COMMANDER: 1 The Swarmlord [foil]
 7 Mountain
 7 Island
 8 Forest
-1 Magus Lucea Kane [foil]
+1 Magus Lucea Kane [40K:174] [foil]
 1 Genestealer Patriarch
 1 Exocrine
 1 The Red Terror

--- a/data/cmd/40k/Tyranid Swarm.txt
+++ b/data/cmd/40k/Tyranid Swarm.txt
@@ -14,7 +14,7 @@ COMMANDER: 1 The Swarmlord [40K:176] [foil]
 1 Icon of Ancestry
 1 Herald's Horn
 1 Sol Ring [40K:249]
-1 Arcane Signet
+1 Arcane Signet [40K:227]
 1 Abundance
 1 Death's Presence
 1 Hardened Scales

--- a/data/cmd/40k/Tyranid Swarm.txt
+++ b/data/cmd/40k/Tyranid Swarm.txt
@@ -38,8 +38,8 @@ COMMANDER: 1 The Swarmlord [40K:176] [foil]
 1 Rugged Highlands
 1 Terramorphic Expanse
 1 Thornwood Falls
-7 Mountain
-7 Island
+7 Mountain [40K:315]
+7 Island [40K:309]
 8 Forest
 1 Magus Lucea Kane [40K:174] [foil]
 1 Genestealer Patriarch


### PR DESCRIPTION
Hello! 
I was taking a look at the decks and I noticed that, same as #14 , there are a few other cards that change the printing depending on the deck it appears. These are the cards: 
```
Mountain
Swamp
Island
Command Tower
Mind Stone
Commander's Sphere
Wayfarer's Bauble
Talisman of Dominance
Arcane Signet
```

Another issue I noticed is the number chosen for the main and alternative commanders. The ones picked are the surge foil versions of the cards, but those only appear in the $100+ Collector's edition of the deck precons. I changed them to the regular foil versions.

I splitted the commits in case it helps reviewing.
