### PR TITLE
Fix Forces of the Imperium (40K) printings and foil printings from CLB and GN3

### DIFF
--- a/data/cmd/40k/Forces of the Imperium.txt
+++ b/data/cmd/40k/Forces of the Imperium.txt
@@ -48,10 +48,10 @@ COMMANDER: 1 Inquisitor Greyfax [40K:173] [foil]
 1 Defenders of Humanity
 1 For the Emperor!
 1 Space Marine Devastator
-1 Triumph of Saint Katherine
+1 Triumph of Saint Katherine [40K:17]
 1 Ultramarines Honour Guard
 1 Vexilus Praetor
-1 Zephyrim
+1 Zephyrim [40K:20]
 1 Sister of Silence
 1 Vanguard Suppressor
 1 Arco-Flagellant

--- a/data/cmd/clb/Draconic Dissent.txt
+++ b/data/cmd/clb/Draconic Dissent.txt
@@ -69,7 +69,7 @@ COMMANDER: 1 Firkraag, Cunning Instigator [CLB:648] [foil]
 1 Terrain Generator
 12 Island
 12 Mountain
-1 Baeloth Barrityl, Entertainer
+1 Baeloth Barrityl, Entertainer [foil]
 1 Clan Crafter
 1 Artificer Class
 1 Astral Dragon

--- a/data/cmd/clb/Draconic Dissent.txt
+++ b/data/cmd/clb/Draconic Dissent.txt
@@ -70,7 +70,7 @@ COMMANDER: 1 Firkraag, Cunning Instigator [CLB:648] [foil]
 12 Island
 12 Mountain
 1 Baeloth Barrityl, Entertainer [foil]
-1 Clan Crafter
+1 Clan Crafter [foil]
 1 Artificer Class
 1 Astral Dragon
 1 Mocking Doppelganger

--- a/data/cmd/clb/Exit from Exile.txt
+++ b/data/cmd/clb/Exit from Exile.txt
@@ -70,7 +70,7 @@ COMMANDER: 1 Faldorn, Dread Wolf Herald [CLB:647] [foil]
 1 Temple of the False God
 11 Mountain
 12 Forest
-1 Durnan of the Yawning Portal
+1 Durnan of the Yawning Portal [foil]
 1 Passionate Archaeologist
 1 Delayed Blast Fireball
 1 Nalfeshnee

--- a/data/cmd/clb/Exit from Exile.txt
+++ b/data/cmd/clb/Exit from Exile.txt
@@ -71,7 +71,7 @@ COMMANDER: 1 Faldorn, Dread Wolf Herald [CLB:647] [foil]
 11 Mountain
 12 Forest
 1 Durnan of the Yawning Portal [foil]
-1 Passionate Archaeologist
+1 Passionate Archaeologist [foil]
 1 Delayed Blast Fireball
 1 Nalfeshnee
 1 Green Slime

--- a/data/cmd/clb/Mind Flayarrrs.txt
+++ b/data/cmd/clb/Mind Flayarrrs.txt
@@ -75,7 +75,7 @@ COMMANDER: 1 Captain N'ghathrod [CLB:646] [foil]
 9 Island
 11 Swamp
 1 Zellix, Sanity Flayer [foil]
-1 Haunted One
+1 Haunted One [foil]
 1 Aboleth Spawn
 1 Endless Evil
 1 Grell Philosopher

--- a/data/cmd/clb/Mind Flayarrrs.txt
+++ b/data/cmd/clb/Mind Flayarrrs.txt
@@ -74,7 +74,7 @@ COMMANDER: 1 Captain N'ghathrod [CLB:646] [foil]
 1 Temple of the False God
 9 Island
 11 Swamp
-1 Zellix, Sanity Flayer
+1 Zellix, Sanity Flayer [foil]
 1 Haunted One
 1 Aboleth Spawn
 1 Endless Evil

--- a/data/cmd/clb/Party Time.txt
+++ b/data/cmd/clb/Party Time.txt
@@ -73,7 +73,7 @@ COMMANDER: 1 Nalia de'Arnise [CLB:649] [foil]
 1 Tainted Field
 10 Plains
 10 Swamp
-1 Burakos, Party Leader
+1 Burakos, Party Leader [foil]
 1 Folk Hero
 1 Deep Gnome Terramancer
 1 Harper Recruiter

--- a/data/cmd/clb/Party Time.txt
+++ b/data/cmd/clb/Party Time.txt
@@ -74,7 +74,7 @@ COMMANDER: 1 Nalia de'Arnise [CLB:649] [foil]
 10 Plains
 10 Swamp
 1 Burakos, Party Leader [foil]
-1 Folk Hero
+1 Folk Hero [foil]
 1 Deep Gnome Terramancer
 1 Harper Recruiter
 1 Seasoned Dungeoneer

--- a/data/game-night/gn3/Boundless Elves.txt
+++ b/data/game-night/gn3/Boundless Elves.txt
@@ -27,6 +27,6 @@
 1 Wirewood Pride
 1 Vow of Wildness
 24 Forest
-1 Imaryll, Elfhame Elite
+1 Imaryll, Elfhame Elite [foil]
 
 Sideboard

--- a/data/game-night/gn3/Dark Sacrifice.txt
+++ b/data/game-night/gn3/Dark Sacrifice.txt
@@ -25,7 +25,7 @@
 1 Demonic Embrace
 1 Liliana's Mastery
 26 Swamp
-1 Vogar, Necropolis Tyrant
+1 Vogar, Necropolis Tyrant [foil]
 1 Vow of Torment
 
 Sideboard

--- a/data/game-night/gn3/Draconic Fury.txt
+++ b/data/game-night/gn3/Draconic Fury.txt
@@ -25,6 +25,6 @@
 1 Dragon Tempest
 1 Vow of Lightning
 25 Mountain
-1 Nogi, Draco-Zealot
+1 Nogi, Draco-Zealot [foil]
 
 Sideboard

--- a/data/game-night/gn3/Glorious Combat.txt
+++ b/data/game-night/gn3/Glorious Combat.txt
@@ -26,6 +26,6 @@
 2 Trusty Machete
 1 Vow of Duty
 26 Plains
-1 Zamriel, Seraph of Steel
+1 Zamriel, Seraph of Steel [foil]
 
 Sideboard

--- a/data/game-night/gn3/Political Trickery.txt
+++ b/data/game-night/gn3/Political Trickery.txt
@@ -25,6 +25,6 @@
 1 Bloodthirsty Blade
 1 Vow of Flight
 25 Island
-1 Maeve, Insidious Singer
+1 Maeve, Insidious Singer [foil]
 
 Sideboard


### PR DESCRIPTION
Hello!
It looks like the Forces of the Imperium deck is picking 2 regular cards as surge foil.
The reason seems to be that the frame effect called "miracle" is missing from the surge foil printing in the Scryfall API, probably due to a bug. That results in the script prioritizing the surge foil one.
I hardcoded the collector number so that they are picked regardless of the frame effect is this situation.

Normal printing has frame effects
https://api.scryfall.com/cards/f78f5b9a-bd80-41e9-873e-826628dc44a7?format=json&pretty=true

Surge foil printing doesn't have frame effects
https://api.scryfall.com/cards/3698b37f-0d86-42ea-9031-8f7e54b5d953?format=json&pretty=true