### PR TITLE
Fix surge foil commanders

### DIFF
--- a/data/cmd/40k/Forces of the Imperium Collector's Edition.txt
+++ b/data/cmd/40k/Forces of the Imperium Collector's Edition.txt
@@ -1,7 +1,7 @@
 // NAME: Forces of the Imperium Collector's Edition
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 Inquisitor Greyfax [40k:173] [foil]
+COMMANDER: 1 Inquisitor Greyfax [40k:3] [foil]
 1 Bastion Protector [40k:182★]
 1 Collective Effort [40k:183★]
 1 Deploy to the Front [40k:184★]
@@ -43,7 +43,7 @@ COMMANDER: 1 Inquisitor Greyfax [40k:173] [foil]
 5 Island [40k:307★]
 7 Swamp [40k:314★]
 8 Plains [40k:306★]
-1 Marneus Calgar [40k:175] [foil]
+1 Marneus Calgar [40k:8] [foil]
 1 Celestine, the Living Saint [40k:10★]
 1 Defenders of Humanity [40k:11★]
 1 For the Emperor! [40k:12★]

--- a/data/cmd/40k/Necron Dynasties Collector's Edition.txt
+++ b/data/cmd/40k/Necron Dynasties Collector's Edition.txt
@@ -1,7 +1,7 @@
 // NAME: Necron Dynasties Collector's Edition
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 Szarekh, the Silent King [40k:170] [foil]
+COMMANDER: 1 Szarekh, the Silent King [40k:1] [foil]
 1 Beacon of Unrest [40k:194★]
 1 Living Death [40k:202★]
 1 Mutilate [40k:203★]
@@ -33,7 +33,7 @@ COMMANDER: 1 Szarekh, the Silent King [40k:170] [foil]
 10 Swamp [40k:310★]
 10 Swamp [40k:312★]
 10 Swamp [40k:313★]
-1 Imotekh the Stormlord [40k:169] [foil]
+1 Imotekh the Stormlord [40k:5] [foil]
 1 Anrakyr the Traveller [40k:28★]
 1 Biotransference [40k:30★]
 1 Chronomancer [40k:32★]

--- a/data/cmd/40k/The Ruinous Powers Collector's Edition.txt
+++ b/data/cmd/40k/The Ruinous Powers Collector's Edition.txt
@@ -1,7 +1,7 @@
 // NAME: The Ruinous Powers Collector's Edition
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 Abaddon the Despoiler [40k:171] [foil]
+COMMANDER: 1 Abaddon the Despoiler [40k:2] [foil]
 1 Past in Flames [40k:206★]
 1 Decree of Pain [40k:198★]
 1 Blasphemous Act [40k:204★]
@@ -39,7 +39,7 @@ COMMANDER: 1 Abaddon the Despoiler [40k:171] [foil]
 8 Mountain [40k:316★]
 8 Swamp [40k:311★]
 8 Island [40k:308★]
-1 Be'lakor, the Dark Master [40k:172] [foil]
+1 Be'lakor, the Dark Master [40k:6] [foil]
 1 Lord of Change [40k:24★]
 1 Blight Grenade [40k:31★]
 1 Great Unclean One [40k:35★]

--- a/data/cmd/40k/Tyranid Swarm Collector's Edition.txt
+++ b/data/cmd/40k/Tyranid Swarm Collector's Edition.txt
@@ -1,7 +1,7 @@
 // NAME: Tyranid Swarm Collector's Edition
 // COMMENTS: https://magic.wizards.com/en/articles/archive/news/warhammer-40000-commander-decklists
 // DATE: 2022-10-07
-COMMANDER: 1 The Swarmlord [40k:176] [foil]
+COMMANDER: 1 The Swarmlord [40k:4] [foil]
 1 Hull Breach [40k:224★]
 1 Cultivate [40k:211★]
 1 Explore [40k:213★]
@@ -41,7 +41,7 @@ COMMANDER: 1 The Swarmlord [40k:176] [foil]
 7 Mountain [40k:315★]
 7 Island [40k:309★]
 8 Forest [40k:317★]
-1 Magus Lucea Kane [40k:174] [foil]
+1 Magus Lucea Kane [40k:7] [foil]
 1 Genestealer Patriarch [40k:22★]
 1 Exocrine [40k:76★]
 1 The Red Terror [40k:83★]


### PR DESCRIPTION
The main and secondary commanders from the 40k collector's edition are the 1-8 numbered cards, which are surge foil.