### PR TITLE
Arena Starter Kit 2021

### DIFF
--- a/data/starter/afr/Rough and Tumble.txt
+++ b/data/starter/afr/Rough and Tumble.txt
@@ -1,0 +1,21 @@
+// NAME: Rough and Tumble
+// SOURCE: https://mtg.fandom.com/wiki/2021_Arena_Starter_Kit
+// DATE: 2021-08-06
+1 Dragonsguard Elite [STX:127] [foil]
+1 Asmodeus the Archfiend [AFR:88]
+2 Black Dragon [AFR:90]
+1 Cleaving Reaper [KHM:376]
+1 Cragplate Baloth [ZNR:183]
+4 Dauntless Survivor [ZNR:184]
+4 Evolving Wilds [AFR:353]
+12 Forest [AFR:281]
+2 Karfell Kennel-Master [KHM:101]
+4 Might of Murasa [ZNR:194]
+3 Murasa Brute [ZNR:195]
+2 Oblivion's Hunger [ZNR:119]
+1 Oran-Rief Ooze [ZNR:198]
+3 Rabid Bite [ZNR:199]
+3 Scurrid Colony [STX:142]
+2 Specter of the Fens [STX:87]
+11 Swamp [AFR:270]
+3 Vampire Spawn [AFR:123]

--- a/data/starter/afr/Sneak Attack.txt
+++ b/data/starter/afr/Sneak Attack.txt
@@ -1,0 +1,20 @@
+// NAME: Sneak Attack
+// SOURCE: https://mtg.fandom.com/wiki/2021_Arena_Starter_Kit
+// DATE: 2021-08-06
+1 Cyclone Summoner [KHM:52] [foil]
+1 Archmage Emeritus [STX:377]
+1 Arni Brokenbrow [KHM:120]
+4 Axgard Cavalry [KHM:121]
+1 Calamity Bearer [KHM:125]
+4 Evolving Wilds [AFR:256]
+2 Field Research [ZNR:58]
+4 Frost Trickster [STX:43]
+11 Island [AFR:269]
+1 Mind Flayer [AFR:63]
+12 Mountain [AFR:277]
+3 Red Dragon [AFR:160]
+4 Run Amok [KHM:147]
+4 Teeterpeak Ambusher [ZNR:169]
+3 Thundering Rebuke [ZNR:170]
+2 Vortex Runner [STX:60]
+2 Wormhole Serpent [STX:62]

--- a/data/starter/snc/Red-Green Starter Deck.txt
+++ b/data/starter/snc/Red-Green Starter Deck.txt
@@ -1,7 +1,7 @@
 // NAME: Red-Green Starter Deck
 // SOURCE: https://magic.wizards.com/en/news/announcements/magic-the-gathering-2022-starter-kit
 // DATE: 2022-06-03
-1 Thundering Raiju
+1 Thundering Raiju [foil]
 1 Ascendant Packleader
 1 Creepy Puppeteer
 1 Topiary Stomper

--- a/data/starter/snc/White-Blue Starter Deck.txt
+++ b/data/starter/snc/White-Blue Starter Deck.txt
@@ -1,7 +1,7 @@
 // NAME: White-Blue Starter Deck
 // SOURCE: https://magic.wizards.com/en/news/announcements/magic-the-gathering-2022-starter-kit
 // DATE: 2022-06-03
-1 Welcoming Vampire
+1 Welcoming Vampire [foil]
 1 Extraction Specialist
 1 Dreamshackle Geist
 1 Hullbreaker Horror


### PR DESCRIPTION
There are 2 decks that were missing, listed here https://mtg.fandom.com/wiki/2021_Arena_Starter_Kit

I've fixed as well the 2 foil cards that are in the 2022 Starter Kit. 
Regarding the 2 decks from Starter Kit 2022, what do you think about renaming them? 

Red-Green Starter Deck -> Earth Shakers
White-Blue Starter Deck -> Up and Away
Source https://mtg.fandom.com/wiki/2022_Starter_Kit

As they are it can be a bit hard to find them because of the name and because they are categorized inside Streets of New Capenna
