### PR TITLE
Core Set 2021 / Arena Starter Kit 2020

### DIFF
--- a/data/starter/m21/Mono Black.txt
+++ b/data/starter/m21/Mono Black.txt
@@ -1,0 +1,20 @@
+// NAME: Mono Green
+// SOURCE: https://mtg.fandom.com/wiki/Core_Set_2021/Arena_Starter_Kit
+// DATE: 2020-07-03
+1 Vito, Thorn of the Dusk Rose [M21:127] [foil]
+2 Blood Glutton [M21:90]
+1 Demon of Loathing [THB:292]
+1 Demonic Embrace [M21:95]
+3 Fetid Imp [M21:98]
+2 Finishing Blow [M21:99]
+3 Gloom Pangolin [IKO:89]
+2 Goremand [M21:101]
+3 Grasp of Darkness [M21:102]
+3 Lost Legion [ELD:94]
+1 Peer into the Abyss [M21:117]
+2 Serrated Scorpion [IKO:99]
+2 Skeleton Archer [M21:123]
+26 Swamp [M21:267]
+1 Underworld Sentinel [THB:293]
+3 Unlikely Aid [IKO:103]
+4 Walking Corpse [M21:128]

--- a/data/starter/m21/Mono Green.txt
+++ b/data/starter/m21/Mono Green.txt
@@ -1,0 +1,20 @@
+// NAME: Mono Green
+// SOURCE: https://mtg.fandom.com/wiki/Core_Set_2021/Arena_Starter_Kit
+// DATE: 2020-07-03
+1 Kogla, the Titan Ape [IKO:162] [foil]
+3 Almighty Brushwagg [IKO:143]
+3 Bristling Boar [IKO:146]
+2 Colossal Dreadmaw [M21:176]
+1 Colossification [IKO:364]
+26 Forest [M21:272]
+2 Honey Mammoth [IKO:158]
+2 Humble Naturalist [IKO:160]
+3 Hyrax Tower Scout [THB:173]
+1 Ironscale Hydra [THB:296]
+3 Llanowar Visionary [M21:193]
+2 Plummet [IKO:169]
+3 Ram Through [IKO:170]
+2 Snarespinner [M21:207]
+4 Titanic Growth [M21:210]
+1 Treeshaker Chimera [THB:297]
+1 Yorvo, Lord of Garenbrig [ELD:185]


### PR DESCRIPTION
Added the Arena Starter Kit (2020) decks. https://mtg.fandom.com/wiki/Core_Set_2021/Arena_Starter_Kit

Unfortunately they do not have a particular name, simply Mono Green and Mono Black.