### PR TITLE
Fix incorrect card name in Izzet Phoenix.txt

### DIFF
--- a/data/pioneer/bro/Izzet Phoenix.txt
+++ b/data/pioneer/bro/Izzet Phoenix.txt
@@ -19,7 +19,7 @@
 1 Steam Vents
 6 Island
 4 Mountain
-2 Thing in the Ice // Awoken Horror
+2 Thing in the Ice
 
 Sideboard
 2 Sweltering Suns


### PR DESCRIPTION
Transform cards should only list the front card name.