### PR TITLE
Add date to 9ed decks

### DIFF
--- a/data/starter/9ed/Gold Deck.txt
+++ b/data/starter/9ed/Gold Deck.txt
@@ -1,5 +1,6 @@
 // NAME: Gold Deck
 // SOURCE: https://mtg.fandom.com/wiki/Ninth_Edition/Core_Game
+// DATE: 2005-08-09
 2 Norwood Ranger
 2 Grizzly Bears
 1 Spined Wurm

--- a/data/starter/9ed/Silver Deck.txt
+++ b/data/starter/9ed/Silver Deck.txt
@@ -1,5 +1,6 @@
 // NAME: Silver Deck
 // SOURCE: https://mtg.fandom.com/wiki/Ninth_Edition/Core_Game
+// DATE: 2005-08-09
 1 Eager Cadet
 4 Glory Seeker
 3 Giant Octopus


### PR DESCRIPTION
The 9ED decks from https://mtg.fandom.com/wiki/Ninth_Edition/Core_Game were missing a release date.
We could add the date that appears in the Amazon site August 9th. The set itself released July 29th, so it could be accurate.

https://www.amazon.com/Magic-Gathering-Core-Wizards-Coast/dp/0786938536

