### PR TITLE
Some printing fixes for the LTR and LTC decks

### DIFF
--- a/data/arena-kit/ltr/Gondor - Green-White.txt
+++ b/data/arena-kit/ltr/Gondor - Green-White.txt
@@ -28,7 +28,7 @@
 1 Stew the Coneys
 1 Butterbur, Bree Innkeeper
 2 Shire Terrace
-2 Graypelt Refuge
+2 Graypelt Refuge [LTC:316]
 11 Forest
 11 Plains
 

--- a/data/arena-kit/ltr/Mordor - Black-Red.txt
+++ b/data/arena-kit/ltr/Mordor - Black-Red.txt
@@ -27,7 +27,7 @@
 1 Mauhúr, Uruk-hai Captain
 1 Uglúk of the White Hand
 1 Mind Stone [LTC:282]
-4 Evolving Wilds
+4 Evolving Wilds [LTC:306]
 11 Swamp
 11 Mountain
 

--- a/data/cmd/ltc/Elven Council.txt
+++ b/data/cmd/ltc/Elven Council.txt
@@ -75,7 +75,9 @@ COMMANDER: 1 Galadriel, Elven-Queen [foil] [LTC:3]
 1 Thornwood Falls
 1 Tranquil Thicket
 1 Woodland Stream
-11 Island
-15 Forest
+6 Island [LTR:264]
+5 Island [LTR:265]
+8 Forest [LTR:270]
+7 Forest [LTR:271]
 
 Sideboard

--- a/data/cmd/ltc/Food and Fellowship.txt
+++ b/data/cmd/ltc/Food and Fellowship.txt
@@ -85,8 +85,11 @@ COMMANDER: 1 Sam, Loyal Attendant [foil] [LTC:7]
 1 Rogue's Passage
 1 Sandsteppe Citadel
 1 Scoured Barrens
-4 Plains
-4 Swamp
-8 Forest
+2 Plains [LTR:262]
+2 Plains [LTR:263]
+2 Swamp [LTR:266]
+2 Swamp [LTR:267]
+4 Forest [LTR:270]
+4 Forest [LTR:271]
 
 Sideboard

--- a/data/cmd/ltc/Riders of Rohan.txt
+++ b/data/cmd/ltc/Riders of Rohan.txt
@@ -82,8 +82,11 @@ COMMANDER: 1 Éowyn, Shieldmaiden [foil] [LTC:1]
 1 Terramorphic Expanse
 1 Tranquil Cove
 1 Wind-Scarred Crag
-9 Plains
-5 Island
-5 Mountain
+5 Plains [LTR:262]
+4 Plains [LTR:263]
+3 Island [LTR:264]
+2 Island [LTR:265]
+3 Mountain [LTR:268]
+2 Mountain [LTR:269]
 
 Sideboard

--- a/data/cmd/ltc/The Hosts of Mordor.txt
+++ b/data/cmd/ltc/The Hosts of Mordor.txt
@@ -82,8 +82,11 @@ COMMANDER: 1 Sauron, Lord of the Rings [foil] [LTC:4]
 1 Path of Ancestry
 1 Rogue's Passage
 1 Terramorphic Expanse
-6 Island
-6 Swamp
-7 Mountain
+3 Island [LTR:264]
+3 Island [LTR:265]
+3 Swamp [LTR:266]
+3 Swamp [LTR:267]
+4 Mountain [LTR:268]
+3 Mountain [LTR:269]
 
 Sideboard


### PR DESCRIPTION
The Starter Kit decks had the wrong version of Evolving Wilds (Mordor deck) and Graypelt Refuge (Gondor deck)

The basic lands in the Commander decks were using the March of the Machine printing.
I've splitted the quantity of each basic land in 2 as that seems to be the way they are arranged from a few openings I've watched.