### PR TITLE
Fix foil cards in LTR Starter kit

### DIFF
--- a/data/starter-kit/ltr/Gondor - Green-White.txt
+++ b/data/starter-kit/ltr/Gondor - Green-White.txt
@@ -1,7 +1,7 @@
 // NAME: Gondor: Green-White
 // SOURCE: https://magic.wizards.com/en/news/announcements/the-lord-of-the-rings-tales-of-middle-earth-starter-kit-decklists
 // DATE: 2023-06-23
-1 Aragorn and Arwen, Wed [LTR:287]
+1 Aragorn and Arwen, Wed [LTR:287] [foil]
 1 Frodo, Determined Hero [LTR:289]
 1 Gandalf, White Rider [LTR:290]
 1 Galadriel, Gift-Giver [LTR:296]

--- a/data/starter-kit/ltr/Mordor - Black-Red.txt
+++ b/data/starter-kit/ltr/Mordor - Black-Red.txt
@@ -1,7 +1,7 @@
 // NAME: Mordor: Black-Red
 // SOURCE: https://magic.wizards.com/en/news/announcements/the-lord-of-the-rings-tales-of-middle-earth-starter-kit-decklists
 // DATE: 2023-06-23
-1 Sauron, the Lidless Eye [LTR:288]
+1 Sauron, the Lidless Eye [LTR:288] [foil]
 1 Gollum, Scheming Guide [LTR:292]
 1 Witch-king, Bringer of Ruin [LTR:293]
 1 Fires of Mount Doom [LTR:294]


### PR DESCRIPTION
Each of the decks has one foil card.