### PR TITLE
phed: Fix collector number for the two commanders

### DIFF
--- a/data/cmd/phed/Heads I Win, Tails You Lose.txt
+++ b/data/cmd/phed/Heads I Win, Tails You Lose.txt
@@ -2,8 +2,8 @@
 // SOURCE: https://mtg.fandom.com/wiki/Secret_Lair_Drop_Series:_Secretversary_2021/Commander_deck
 // DATE: 2022-04-22
 // DISPLAY: Also includes one of: foil [SLD:673] Island or foil [SLD:674] Mountain
-COMMANDER: 1 Zndrsplt, Eye of Wisdom [SLD:379★a]
-COMMANDER: 1 Okaun, Eye of Chaos [SLD:380★a]
+COMMANDER: 1 Zndrsplt, Eye of Wisdom [SLD:379a]
+COMMANDER: 1 Okaun, Eye of Chaos [SLD:380a]
 1 Daretti, Scrap Savant [foil]
 1 Ral Zarek [foil]
 1 Goblin Kaboomist [foil]


### PR DESCRIPTION
This picked the thick variant, which is not tournament legal.