### PR TITLE
Rename DPA decks to only contain the name of the deck

### DIFF
--- a/data/dotp/dpa/Ears of the Elves.txt
+++ b/data/dotp/dpa/Ears of the Elves.txt
@@ -1,4 +1,4 @@
-// NAME: Ears of the Elves - The Nissa Revane Deck
+// NAME: Ears of the Elves
 // SOURCE: https://magic.wizards.com/en/articles/archive/duels-planeswalkers-decks-2010-05-25-0
 // DATE: 2010-06-04
 1 Immaculate Magistrate [foil]

--- a/data/dotp/dpa/Eyes of Shadow.txt
+++ b/data/dotp/dpa/Eyes of Shadow.txt
@@ -1,4 +1,4 @@
-// NAME: Eyes of Shadow - The Liliana Vess Deck
+// NAME: Eyes of Shadow
 // SOURCE: https://magic.wizards.com/en/articles/archive/duels-planeswalkers-decks-2010-05-25-0
 // DATE: 2010-06-04
 3 Drudge Skeletons

--- a/data/dotp/dpa/Hands of Flame.txt
+++ b/data/dotp/dpa/Hands of Flame.txt
@@ -1,4 +1,4 @@
-// NAME: Hands of Flame - The Chandra Nalaar Deck
+// NAME: Hands of Flame
 // SOURCE: https://magic.wizards.com/en/articles/archive/duels-planeswalkers-decks-2010-05-25-0
 // DATE: 2010-06-04
 4 Goblin Piker

--- a/data/dotp/dpa/Teeth of the Predator.txt
+++ b/data/dotp/dpa/Teeth of the Predator.txt
@@ -1,4 +1,4 @@
-// NAME: Teeth of the Predator - The Garruk Wildspeaker Deck
+// NAME: Teeth of the Predator
 // SOURCE: https://magic.wizards.com/en/articles/archive/duels-planeswalkers-decks-2010-05-25-0
 // DATE: 2010-06-04
 1 Verdant Force [foil]

--- a/data/dotp/dpa/Thoughts of the Wind.txt
+++ b/data/dotp/dpa/Thoughts of the Wind.txt
@@ -1,4 +1,4 @@
-// NAME: Thoughts of the Wind - The Jace Beleren Deck
+// NAME: Thoughts of the Wind
 // SOURCE: https://magic.wizards.com/en/articles/archive/duels-planeswalkers-decks-2010-05-25-0
 // DATE: 2010-06-04
 4 Cloud Sprite


### PR DESCRIPTION
Anything after the dash is redundant and this brings this set closer to how other decks are handled (ie a short identifiable name).