### PR TITLE
Add SDCC sets

### DIFF
--- a/data/sdcc/SDCC 2013 Planeswalker Set.txt
+++ b/data/sdcc/SDCC 2013 Planeswalker Set.txt
@@ -1,0 +1,8 @@
+// NAME: SDCC 2013 Planeswalker Set
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2013-07-18
+1 Ajani, Caller of the Pride [PSDC]
+1 Jace, Memory Adept [PSDC]
+1 Liliana of the Dark Realms [PSDC]
+1 Chandra, Pyromaster [PSDC]
+1 Garruk, Caller of Beasts [PSDC]

--- a/data/sdcc/SDCC 2014 Planeswalker Set.txt
+++ b/data/sdcc/SDCC 2014 Planeswalker Set.txt
@@ -1,0 +1,9 @@
+// NAME: SDCC 2014 Planeswalker Set
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2014-07-24
+1 Ajani Steadfast [PS14]
+1 Jace, the Living Guildpact [PS14]
+1 Liliana Vess [PS14]
+1 Chandra, Pyromaster [PS14]
+1 Nissa, Worldwaker [PS14]
+1 Garruk, Apex Predator [PS14]

--- a/data/sdcc/SDCC 2015 Planeswalker Set.txt
+++ b/data/sdcc/SDCC 2015 Planeswalker Set.txt
@@ -1,0 +1,8 @@
+// NAME: SDCC 2015 Planeswalker Set
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2015-07-09
+1 Kytheon, Hero of Akros // Gideon, Battle-Forged [PS15]
+1 Jace, Vryn's Prodigy // Jace, Telepath Unbound [PS15]
+1 Liliana, Heretical Healer // Liliana, Defiant Necromancer [PS15]
+1 Chandra, Fire of Kaladesh // Chandra, Roaring Flame [PS15]
+1 Nissa, Vastwood Seer // Nissa, Sage Animist [PS15]

--- a/data/sdcc/SDCC 2016 Zombie Planeswalker Set.txt
+++ b/data/sdcc/SDCC 2016 Zombie Planeswalker Set.txt
@@ -1,0 +1,8 @@
+// NAME: SDCC 2016 Zombie Planeswalker Set
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2016-07-21
+1 Gideon, Ally of Zendikar [PS16]
+1 Jace, Unraveler of Secrets [PS16]
+1 Liliana, the Last Hope [PS16]
+1 Chandra, Flamecaller [PS16]
+1 Nissa, Voice of Zendikar [PS16]

--- a/data/sdcc/SDCC 2017 Planeswalker Set.txt
+++ b/data/sdcc/SDCC 2017 Planeswalker Set.txt
@@ -1,0 +1,9 @@
+// NAME: SDCC 2017 Planeswalker Set
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2017-07-20
+1 Gideon of the Trials [PS17]
+1 Jace, Unraveler of Secrets [PS17]
+1 Liliana, Death's Majesty [PS17]
+1 Chandra, Torch of Defiance [PS17]
+1 Nissa, Steward of Elements [PS17]
+1 Nicol Bolas, God-Pharaoh [PS17]

--- a/data/sdcc/SDCC 2018 Planeswalker Set.txt
+++ b/data/sdcc/SDCC 2018 Planeswalker Set.txt
@@ -1,0 +1,8 @@
+// NAME: SDCC 2018 Planeswalker Set
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2018-07-19
+1 Gideon of the Trials [PS18]
+1 Jace, Cunning Castaway [PS18]
+1 Liliana, Untouched by Death [PS18]
+1 Chandra, Torch of Defiance [PS18]
+1 Nissa, Vital Force [PS18]

--- a/data/sdcc/SDCC 2019 Dragon's Endgame.txt
+++ b/data/sdcc/SDCC 2019 Dragon's Endgame.txt
@@ -1,0 +1,8 @@
+// NAME: Dragon's Endgame
+// SOURCE: https://mtg.fandom.com/wiki/Comic-Con
+// DATE: 2019-07-18
+1 God-Eternal Bontu [PS19]
+1 God-Eternal Kefnet [PS19]
+1 God-Eternal Oketra [PS19]
+1 God-Eternal Rhonas [PS19]
+1 Nicol Bolas, Dragon-God [PS19]


### PR DESCRIPTION
the 2013-2018 don't have an official name, so i went with the standard scheme on tcg
I didn't add "Set" to the last box of 2019, but if needed for consistency i can add it