### PR TITLE
sld: Remove card that is not actually present in the products

### DIFF
--- a/data/sld/sld/Valentines Day 2021 foil.txt
+++ b/data/sld/sld/Valentines Day 2021 foil.txt
@@ -2,7 +2,6 @@
 // SOURCE: https://mtg.fandom.com/wiki/Secret_Lair_Drop_Series:_Smitten_Superdrop
 // DATE: 2021-02-12
 // DISPLAY: Due to a technical issue, this secret lair drop was shipped without Heliod, Sun-Crowned. The card was shipped after-the-fact to all affected customers along with 5 additional goblin tokens.
-1 [SLD:214] Heliod, Sun-Crowned [foil]
 1 [SLD:215] Goblin Rabblemaster [foil]
 1 [SLD:216] Monastery Swiftspear [foil]
 1 [SLD:217] Boros Charm [foil]

--- a/data/sld/sld/Valentines Day 2021.txt
+++ b/data/sld/sld/Valentines Day 2021.txt
@@ -2,7 +2,6 @@
 // SOURCE: https://mtg.fandom.com/wiki/Secret_Lair_Drop_Series:_Smitten_Superdrop
 // DATE: 2021-02-12
 // DISPLAY: Due to a technical issue, this secret lair drop was shipped without Heliod, Sun-Crowned. The card was shipped after-the-fact to all affected customers along with 5 additional goblin tokens.
-1 [SLD:214] Heliod, Sun-Crowned
 1 [SLD:215] Goblin Rabblemaster
 1 [SLD:216] Monastery Swiftspear
 1 [SLD:217] Boros Charm


### PR DESCRIPTION
This card was never shipped so it shouldn't count towards the decklist. The DISPLAY note should be enough.

Alternatively we could set the count to 0 but I don't know how the system will react (and seems counter intuitive)
