### PR TITLE
fix non existing printing

### DIFF
--- a/data/challenger/q07/Gruul Stompy.txt
+++ b/data/challenger/q07/Gruul Stompy.txt
@@ -24,7 +24,7 @@ Sideboard
 3 Thundering Rebuke
 2 Tovolar, Dire Overlord
 3 Burning Hands
-1 Kappa Tech-Wrecker [NEO:302]
+1 Kappa Tech-Wrecker [NEO:348]
 1 Kappa Tech-Wrecker
 2 Lantern of the Lost
 1 Froghemoth


### PR DESCRIPTION
There was a typo on a card fix from the last PR. I missed the warning when generating the decks json data