### PR TITLE
Set Vizzerdrix number in starter decks to reduce warnings

### DIFF
--- a/data/starter-std/8ed/Silver Deck.txt
+++ b/data/starter-std/8ed/Silver Deck.txt
@@ -4,7 +4,7 @@
 1 Eager Cadet
 4 Glory Seeker
 3 Giant Octopus
-2 Vizzerdrix
+2 Vizzerdrix [8ED:S5]
 2 Coral Eel
 1 Fugitive Wizard
 2 Sacred Nectar

--- a/data/starter-std/9ed/Silver Deck.txt
+++ b/data/starter-std/9ed/Silver Deck.txt
@@ -4,7 +4,7 @@
 1 Eager Cadet
 4 Glory Seeker
 3 Giant Octopus
-2 Vizzerdrix
+2 Vizzerdrix [9ED:S7]
 2 Coral Eel
 1 Fugitive Wizard
 2 Sacred Nectar


### PR DESCRIPTION
part of https://github.com/taw/magic-search-engine/issues/345