### PR TITLE
Missing SLD decks

### DIFF
--- a/data/sld/sld/Back in My Day! Foil Edition.txt
+++ b/data/sld/sld/Back in My Day! Foil Edition.txt
@@ -1,0 +1,7 @@
+// NAME: Back in My Day! Foil Edition
+// SOURCE: https://www.reddit.com/r/magicTCG/comments/1ta5y16/sld_back_in_my_day/
+// DATE: 2026-05-29
+1 [SLD:2346] Battle Hymn [foil]
+1 [SLD:2347] Breath of Fury [foil]
+1 [SLD:2348] Veil of Summer [foil]
+1 [SLD:2349] Birthing Pod [foil]

--- a/data/sld/sld/Back in My Day!.txt
+++ b/data/sld/sld/Back in My Day!.txt
@@ -1,0 +1,7 @@
+// NAME: Back in My Day!
+// SOURCE: https://www.reddit.com/r/magicTCG/comments/1ta5y16/sld_back_in_my_day/
+// DATE: 2026-05-29
+1 [SLD:2346] Battle Hymn
+1 [SLD:2347] Breath of Fury
+1 [SLD:2348] Veil of Summer
+1 [SLD:2349] Birthing Pod

--- a/data/sld/sld/Inked Foil Edition.txt
+++ b/data/sld/sld/Inked Foil Edition.txt
@@ -1,0 +1,8 @@
+// NAME: Inked Foil Edition
+// SOURCE: https://www.reddit.com/r/SecretLairMTG/comments/1sm5tr3/inked_secret_lair_drop_mfg_2025_scrapped_or_still/
+// DATE: 2026-05-29
+1 [SLD:168] Mulldrifter [foil]
+1 [SLD:169] Crypt Ghast [foil]
+1 [SLD:170] Deathrite Shaman [foil]
+1 [SLD:171] Ice-Fang Coatl [foil]
+1 [SLD:172] Burnished Hart [foil]

--- a/data/sld/sld/Inked.txt
+++ b/data/sld/sld/Inked.txt
@@ -1,0 +1,8 @@
+// NAME: Inked
+// SOURCE: https://www.reddit.com/r/SecretLairMTG/comments/1sm5tr3/inked_secret_lair_drop_mfg_2025_scrapped_or_still/
+// DATE: 2026-05-29
+1 [SLD:168] Mulldrifter
+1 [SLD:169] Crypt Ghast
+1 [SLD:170] Deathrite Shaman
+1 [SLD:171] Ice-Fang Coatl
+1 [SLD:172] Burnished Hart

--- a/data/sld/sld/Omens of Chaos Foil Edition.txt
+++ b/data/sld/sld/Omens of Chaos Foil Edition.txt
@@ -1,8 +1,8 @@
 // NAME: Omens of Chaos Foil Edition
 // SOURCE: https://secretlair.wizards.com/us/product/1250293
 // DATE: 2026-05-12
-1 [SLD] Batwing Brume [foil]
 1 [SLD:2468] Abrupt Decay [foil]
+1 [SLD:2469] Batwing Brume [foil]
 1 [SLD:2470] Chance for Glory [foil]
 1 [SLD:2471] Counterflux [foil]
 1 [SLD:2472] Growth Spiral [foil]

--- a/data/sld/sld/Omens of Chaos.txt
+++ b/data/sld/sld/Omens of Chaos.txt
@@ -1,8 +1,8 @@
 // NAME: Omens of Chaos
 // SOURCE: https://secretlair.wizards.com/us/product/1250294
 // DATE: 2026-05-12
-1 [SLD] Batwing Brume
 1 [SLD:2468] Abrupt Decay
+1 [SLD:2469] Batwing Brume
 1 [SLD:2470] Chance for Glory
 1 [SLD:2471] Counterflux
 1 [SLD:2472] Growth Spiral

--- a/data/sld/sld/So Salty.txt
+++ b/data/sld/sld/So Salty.txt
@@ -1,0 +1,8 @@
+// NAME: So Salty
+// SOURCE: https://www.reddit.com/r/SecretLairMTG/comments/1s4c30k/new_so_salty_roadshow_secret_lair_unveiled_at_pax/
+// DATE: 2025-04-22
+1 [SLD:2396] Expropriate [foil]
+1 [SLD:2397] Narset, Parter of Veils [foil]
+1 [SLD:2398] Scrawling Crawler [foil]
+1 [SLD:2399] Worst Fears [foil]
+1 [SLD:2400] Winter Orb [foil]


### PR DESCRIPTION
went manual since these are not explicitly findable on the secretlair website