### PR TITLE
Savage Hunter -> Savage Hunger

### DIFF
--- a/data/brawl/eld/Savage Hunger.txt
+++ b/data/brawl/eld/Savage Hunger.txt
@@ -1,4 +1,4 @@
-// NAME: Savage Hunter
+// NAME: Savage Hunger
 // SOURCE: https://magic.wizards.com/en/articles/archive/card-preview/inside-throne-eldraine-brawl-decks-2019-09-04
 // DATE: 2019-10-04
 COMMANDER: 1 Korvold, Fae-Cursed King [foil]


### PR DESCRIPTION
It looks there was a typo in the original announcement

https://magic.wizards.com/en/news/card-preview/inside-throne-eldraine-brawl-decks-2019-09-04

<img width="620" height="708" alt="image" src="https://github.com/user-attachments/assets/fb98f4c7-90da-4965-ae27-3b208a17b799" />
