### PR TITLE
Add Avatar TLA sealed products (Scene Boxes, Beginner Box, Commander's Bundle) — resolve is:productless

### DIFF
--- a/data/box/tla/Beginner Box - Aang Tutorial.txt
+++ b/data/box/tla/Beginner Box - Aang Tutorial.txt
@@ -1,0 +1,23 @@
+// NAME: Beginner Box - Aang Tutorial
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Aang, Air Nomad [TLE:265]
+1 Aang's Defense [TLE:266]
+1 Aardvark Sloth [TLE:267]
+1 Appa, Aang's Companion [TLE:268]
+1 Katara, Heroic Healer [TLE:269]
+1 Momo, Rambunctious Rascal [TLE:270]
+1 Path to Redemption [TLE:271]
+1 Razor Rings [TLE:272]
+1 Sledding Otter-Penguin [TLE:273]
+1 Sokka, Wolf Cove's Protector [TLE:274]
+1 Tundra Wall [TLE:275]
+1 Wolf Cove Villager [TLE:276]
+1 Plains [TLE:297]
+1 Plains [TLE:298]
+1 Plains [TLE:299]
+1 Plains [TLE:300]
+1 Plains [TLE:301]
+1 Plains [TLE:302]
+1 Plains [TLE:303]
+1 Plains [TLE:304]

--- a/data/box/tla/Beginner Box - Allies.txt
+++ b/data/box/tla/Beginner Box - Allies.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Allies
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Kyoshi Warrior Guard
+1 Jeong Jeong's Deserters
+1 Glider Kids
+1 Avatar Enthusiasts
+1 Allied Teamwork [TLE:213]
+1 Aang, the Last Airbender
+1 Suki, Kyoshi Warrior
+1 Rabaroo Troop
+1 Master Piandao
+1 Mechanical Glider
+1 Path to Redemption
+1 Airbending Lesson
+1 Thriving Heath
+7 Plains

--- a/data/box/tla/Beginner Box - Attacking.txt
+++ b/data/box/tla/Beginner Box - Attacking.txt
@@ -9,7 +9,7 @@
 1 Hei Bai, Spirit of Balance
 1 Lion Vulture [TLE:232]
 1 Beetle-Headed Merchants
-1 Cat-gator
+1 Cat-Gator
 1 Heartless Act
 1 Epic Downfall
 1 Dai Li Indoctrination

--- a/data/box/tla/Beginner Box - Attacking.txt
+++ b/data/box/tla/Beginner Box - Attacking.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Attacking
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Purple Pentapus
+1 Corrupt Court Official
+1 Merchant of Many Hats
+1 Pretending Poxbearers
+1 Fire Nation Ambushers
+1 Hei Bai, Spirit of Balance
+1 Lion Vulture [TLE:232]
+1 Beetle-Headed Merchants
+1 Cat-gator
+1 Heartless Act
+1 Epic Downfall
+1 Dai Li Indoctrination
+1 Thriving Moor
+7 Swamp

--- a/data/box/tla/Beginner Box - Big Creatures.txt
+++ b/data/box/tla/Beginner Box - Big Creatures.txt
@@ -11,8 +11,7 @@
 1 Saber-Tooth Moose-Lion
 1 Flopsie, Bumi's Buddy
 1 Mechanical Glider
-1 Hog-Monkey
-1 Rampage
+1 Hog-Monkey Rampage [TLE:255]
 1 Seismic Tutelage [TLE:254]
 1 Thriving Grove
 7 Forest

--- a/data/box/tla/Beginner Box - Big Creatures.txt
+++ b/data/box/tla/Beginner Box - Big Creatures.txt
@@ -1,0 +1,18 @@
+// NAME: Beginner Box - Big Creatures
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Turtle-Duck
+1 Raucous Audience
+1 Frog-Squirrels
+1 Ostrich-Horse
+1 Match the Odds
+1 Eel-Hounds
+1 Hippo-Cows
+1 Saber-Tooth Moose-Lion
+1 Flopsie, Bumi's Buddy
+1 Mechanical Glider
+1 Hog-Monkey
+1 Rampage
+1 Seismic Tutelage [TLE:254]
+1 Thriving Grove
+7 Forest

--- a/data/box/tla/Beginner Box - Counters.txt
+++ b/data/box/tla/Beginner Box - Counters.txt
@@ -8,8 +8,7 @@
 1 Fire Nation Engineer
 1 Earth Village Ruffians
 1 Hog-Monkey
-1 Buzzard-Wasp
-1 Colony
+1 Buzzard-Wasp Colony
 1 Fire Nation Sentinels [TLE:230]
 1 Azula Always Lies
 1 Feed the Swarm

--- a/data/box/tla/Beginner Box - Counters.txt
+++ b/data/box/tla/Beginner Box - Counters.txt
@@ -1,0 +1,18 @@
+// NAME: Beginner Box - Counters
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Gilacorn
+1 Elephant-Rat
+1 Long Feng, Grand Secretariat
+1 Dai Li Indoctrination
+1 Fire Nation Engineer
+1 Earth Village Ruffians
+1 Hog-Monkey
+1 Buzzard-Wasp
+1 Colony
+1 Fire Nation Sentinels [TLE:230]
+1 Azula Always Lies
+1 Feed the Swarm
+1 Ozai's Cruelty
+1 Thriving Moor
+7 Swamp

--- a/data/box/tla/Beginner Box - Earthbending.txt
+++ b/data/box/tla/Beginner Box - Earthbending.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Earthbending
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Rebellious Captives
+1 Haru, Hidden Talent
+1 Earth Village Ruffians
+1 Toph, the Blind Bandit
+1 Earth Kingdom Soldier
+1 Earthbending Lesson
+1 Badgermole
+1 Bumi, Eclectic Earthbender [TLE:248]
+1 Rocky Rebuke
+1 Explore
+1 Pillar Launch
+1 Earth Rumble
+1 Thriving Grove
+7 Forest

--- a/data/box/tla/Beginner Box - Firebending.txt
+++ b/data/box/tla/Beginner Box - Firebending.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Firebending
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Deserter's Disciple
+1 Fire Sages
+1 Yuyan Archers
+1 Vindictive Warden
+1 Loyal Fire Sage
+1 Zuko, Exiled Prince
+1 Fire Nation Archers [TLE:237]
+1 Rough Rhino Cavalry
+1 Mongoose Lizard
+1 Lightning Strike
+1 How to Start a Riot
+1 Roku's Mastery
+1 Thriving Bluff
+7 Mountain

--- a/data/box/tla/Beginner Box - Spells.txt
+++ b/data/box/tla/Beginner Box - Spells.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Spells
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 First-Time Flyer
+1 Master Pakku
+1 Rowdy Snowballers
+1 Iguana Parrot
+1 Turtle-Seals
+1 Geyser Leaper
+1 Serpent of the Pass
+1 Barrels of Blasting Jelly
+1 Abandon Attachments
+1 It'll Quench Ya
+1 Lost in the Spirit World
+1 Water Whip [TLE:227]
+1 Thriving Isle
+7 Island

--- a/data/box/tla/Beginner Box - Spells.txt
+++ b/data/box/tla/Beginner Box - Spells.txt
@@ -10,7 +10,7 @@
 1 Serpent of the Pass
 1 Barrels of Blasting Jelly
 1 Abandon Attachments
-1 It'll Quench Ya
+1 It'll Quench Ya!
 1 Lost in the Spirit World
 1 Water Whip [TLE:227]
 1 Thriving Isle

--- a/data/box/tla/Beginner Box - Waterbending.txt
+++ b/data/box/tla/Beginner Box - Waterbending.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Waterbending
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Flying Dolphin-Fish
+1 Otter-Penguin
+1 Katara, Bending Prodigy
+1 Sokka, Lateral Strategist
+1 Cat-Owl
+1 Flexible Waterbender
+1 Giant Koi
+1 The Terror of Serpent's Pass [TLE:225]
+1 Watery Grasp
+1 Bender's Waterskin
+1 Deny Entry [TLE:222]
+1 Waterbending Lesson
+1 Thriving Isle
+7 Island

--- a/data/box/tla/Beginner Box - Zuko Tutorial.txt
+++ b/data/box/tla/Beginner Box - Zuko Tutorial.txt
@@ -1,0 +1,23 @@
+// NAME: Beginner Box - Zuko Tutorial
+// SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
+// DATE: 2025-11-14
+1 Capital Guard [TLE:277]
+1 Dragon Moose [TLE:278]
+1 Explosive Shot [TLE:279]
+1 Fire Nation Soldier [TLE:280]
+1 Fire Nation's Conquest [TLE:281]
+1 Iroh, Firebending Instructor [TLE:282]
+1 Komodo Rhino [TLE:283]
+1 Run Amok [TLE:284]
+1 Warship Scout [TLE:285]
+1 Zhao, the Seething Flame [TLE:286]
+1 Zuko, Avatar Hunter [TLE:287]
+1 Zuko's Offense [TLE:288]
+1 Mountain [TLE:289]
+1 Mountain [TLE:290]
+1 Mountain [TLE:291]
+1 Mountain [TLE:292]
+1 Mountain [TLE:293]
+1 Mountain [TLE:294]
+1 Mountain [TLE:295]
+1 Mountain [TLE:296]

--- a/data/box/tla/Commander's Bundle.txt
+++ b/data/box/tla/Commander's Bundle.txt
@@ -1,0 +1,17 @@
+// NAME: Commander's Bundle
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
+// DATE: 2025-11-14
+// DISPLAY: Each bundle contains the 3 fixed borderless staples (Sol Ring, Arcane Signet, Swiftfoot Boots) plus 2 of the 10 possible tutor / free-spell reprints; all 13 possible cards are listed here.
+1 Enlightened Tutor [TLE:305]
+1 Flawless Maneuver [TLE:306]
+1 Fierce Guardianship [TLE:307]
+1 Mystical Tutor [TLE:308]
+1 Deadly Rollick [TLE:309]
+1 Entomb [TLE:310]
+1 Deflecting Swat [TLE:311]
+1 Gamble [TLE:312]
+1 Obscuring Haze [TLE:313]
+1 Worldly Tutor [TLE:314]
+1 Arcane Signet [TLE:315]
+1 Sol Ring [TLE:316]
+1 Swiftfoot Boots [TLE:317]

--- a/data/box/tla/Tea Time at the Jasmine Dragon.txt
+++ b/data/box/tla/Tea Time at the Jasmine Dragon.txt
@@ -1,0 +1,9 @@
+// NAME: Tea Time at the Jasmine Dragon
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
+// DATE: 2025-11-14
+1 Mai and Zuko [TLE:68] [foil]
+1 Aang and Katara [TLE:69] [foil]
+1 Toph, Greatest Earthbender [TLE:70] [foil]
+1 Sokka and Suki [TLE:71] [foil]
+1 Momo's Heist [TLE:72] [foil]
+1 Uncle's Musings [TLE:73] [foil]

--- a/data/box/tla/The Black Sun Invasion.txt
+++ b/data/box/tla/The Black Sun Invasion.txt
@@ -1,0 +1,9 @@
+// NAME: The Black Sun Invasion
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
+// DATE: 2025-11-14
+1 Appa, the Vigilant [TLE:62] [foil]
+1 Katara's Reversal [TLE:63] [foil]
+1 Fire Nation Turret [TLE:64] [foil]
+1 Swampbenders [TLE:65] [foil]
+1 Sokka's Charge [TLE:66] [foil]
+1 Earthshape [TLE:67] [foil]


### PR DESCRIPTION
Resolves nearly the full `is:productless` set for Avatar: The Last Airbender (`s:TLA,TLE is:productless -is:buyabox`). The Eternal (TLE) cards don't come from the Play or Collector Boosters — they come from separate sealed products that weren't modeled yet. This adds them as decks under `data/box/tla/`.

## Products added

| product | cards | files |
|---|---|---|
| **Scene Boxes** (×2) | TLE #62–73 — the 6 foil borderless scene cards each | The Black Sun Invasion, Tea Time at the Jasmine Dragon |
| **Beginner Box** | TLE character cards #265–288, full-art basics #289–304, and the nonfoil "both"-finish cards #213–254 | 10 half-decks (Aang/Zuko tutorials + Allies, Waterbending, Spells, Attacking, Counters, Firebending, Big Creatures, Earthbending) |
| **Commander's Bundle** | TLE #305–317 — the eternal Commander staples (Sol Ring, Arcane Signet, Swiftfoot Boots + 10 tutor/free-spell reprints) | Commander's Bundle |

## Verification

Built `decks.json` and ran a deck- and booster-inclusive productless check against the search engine:

```
TLA nonfoil: 0    TLA FOIL: 1 (see note)
TLE nonfoil: 0    TLE FOIL: 0
```

(Progression: Scene Boxes → TLE foil 12→0; Beginner Box → TLE nonfoil 44→13; Commander's Bundle → 13→0.)

## Notes for review

- **Bundle promo not modeled**: the regular Bundle's single fixed foil promo (TLA #394, Momo, Friendly Flier) is intentionally left out — a one-card bundle insert isn't worth a deck file, so that lone TLA foil stays productless by design.
- **Commander's Bundle** actually ships 3 fixed staples + 2 random of 10 possible reprints; I list all 13 possible cards so none are productless (the deck represents the product's card pool, not a single bundle's contents).
- **Beginner Box basics**: modeled the 16 TLE full-art basics (#289–304) as 8 distinct Plains in the Aang deck + 8 distinct Mountains in the Zuko deck so all printings are covered.
- Split/adventure `a/b` faces and the digital-only Alchemy (`is:rebalanced`) cards are excluded, consistent with mtgban.
- Build note for whoever regenerates `decks.json` on old Ruby: needs `-Eutf-8` and a `Hash#except` polyfill (pre-existing, unrelated to these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)