### PR TITLE
Add FINAL FANTASY Scene Boxes (resolve foil is:productless)

### DIFF
--- a/data/box/fin/Camp Comrades.txt
+++ b/data/box/fin/Camp Comrades.txt
@@ -1,0 +1,10 @@
+// NAME: Camp Comrades
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-final-fantasy
+// DATE: 2025-06-13
+// DISPLAY: FINAL FANTASY XV Scene Box - 6 traditional foil borderless scene cards
+1 Noctis, Heir Apparent [FIC:460] [foil]
+1 Fishing Gear [FIC:461] [foil]
+1 Chocobo Camp [FIC:462] [foil]
+1 Flash Photography [FIC:463] [foil]
+1 Campsite Cuisine [FIC:464] [foil]
+1 Warrior's Resolve [FIC:465] [foil]

--- a/data/box/fin/Children of Fate.txt
+++ b/data/box/fin/Children of Fate.txt
@@ -1,0 +1,10 @@
+// NAME: Children of Fate
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-final-fantasy
+// DATE: 2025-06-13
+// DISPLAY: FINAL FANTASY VIII Scene Box - 6 traditional foil borderless scene cards
+1 Edea, Possessed Sorceress [FIC:448] [foil]
+1 Fated Clash [FIC:449] [foil]
+1 Rinoa, Angel Wing [FIC:450] [foil]
+1 Seifer, Balamb Rival [FIC:451] [foil]
+1 Duelist's Flame [FIC:452] [foil]
+1 Squall, Gunblade Duelist [FIC:453] [foil]

--- a/data/box/fin/Garland at the Chaos Shrine.txt
+++ b/data/box/fin/Garland at the Chaos Shrine.txt
@@ -1,0 +1,10 @@
+// NAME: Garland at the Chaos Shrine
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-final-fantasy
+// DATE: 2025-06-13
+// DISPLAY: FINAL FANTASY I Scene Box - 6 traditional foil borderless scene cards
+1 Garland, Royal Kidnapper [FIC:442] [foil]
+1 The Destined Warrior [FIC:443] [foil]
+1 The Destined White Mage [FIC:444] [foil]
+1 Chaos Shrine's Black Crystal [FIC:445] [foil]
+1 The Destined Thief [FIC:446] [foil]
+1 The Destined Black Mage [FIC:447] [foil]

--- a/data/box/fin/The Siege of Alexandria.txt
+++ b/data/box/fin/The Siege of Alexandria.txt
@@ -1,0 +1,10 @@
+// NAME: The Siege of Alexandria
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-final-fantasy
+// DATE: 2025-06-13
+// DISPLAY: FINAL FANTASY IX Scene Box - 6 traditional foil borderless scene cards
+1 Brilliant Wings [FIC:454] [foil]
+1 Judgment of Alexander [FIC:455] [foil]
+1 Mega Flare [FIC:456] [foil]
+1 Amarant Coral [FIC:457] [foil]
+1 Vivi's Persistence [FIC:458] [foil]
+1 Search for Dagger [FIC:459] [foil]


### PR DESCRIPTION
## Summary

Models the four **FINAL FANTASY Scene Boxes**, resolving the real FIN/FIC foil `is:productless` cards.

Each Scene Box contains **6 traditional foil borderless scene cards** (FIC #442–465). Their *nonfoil* versions were already covered by the Chocobo Bundle scene slot (`fin-chocobo-bundle-scene.yaml`), but the *foils* had no product mapping — all 24 showed as `is:productless`.

| Scene Box | Game | Cards |
|---|---|---|
| Garland at the Chaos Shrine | FF I | FIC #442–447 |
| Children of Fate | FF VIII | FIC #448–453 |
| The Siege of Alexandria | FF IX | FIC #454–459 |
| Camp Comrades | FF XV | FIC #460–465 |

## Verification

Ran the productless checker against the search-engine index before/after:

| group | before | after |
|---|---|---|
| FIC foil | 29 | 5 |

The remaining entries are the usual data-model artifacts, **not** real product gaps:
- split / adventure back-faces (`#83b` Gentleman's Rise, `#264b` Mesmeric Glare, `#279b` Swift End)
- Kuja `†a` meld-face duplicates (each has a covered non-dagger twin)

Sources: [Card Game Base scene box list](https://cardgamebase.com/final-fantasy-scene-boxes-card-list-review/), official Amazon product listings (Garland at the Chaos Shrine, Children of Fate, The Siege of Alexandria, Camp Comrades).

🤖 Generated with [Claude Code](https://claude.com/claude-code)