### PR TITLE
Add Secrets of Strixhaven Welcome Decks (resolve FDN #731-771 is:productless)

### DIFF
--- a/data/welcome/sos/Black Deck.txt
+++ b/data/welcome/sos/Black Deck.txt
@@ -1,0 +1,25 @@
+// NAME: Black Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
+// DATE: 2026-04-24
+1 Vampire Interloper [FDN:756]
+2 Gutless Plunderer
+2 Eaten Alive
+1 Vampire Neonate
+1 Vampire Gourmand
+2 Hero's Downfall
+1 Stromkirk Bloodthief
+1 Vampire Soulcaller [FDN:758]
+1 Crossway Troublemakers
+1 Vampire Nighthawk [FDN:757]
+1 Kalastria Highborn [FDN:753]
+1 Zombify
+1 Macabre Waltz
+1 Vengeful Bloodwitch
+1 Vampire Spawn
+1 Massacre Wurm [FDN:754]
+1 Bloodtithe Collector [FDN:751]
+1 Rogue's Passage
+1 Gatekeeper of Malakir [FDN:752]
+1 Sanguine Syphoner
+1 Pulse Tracker [FDN:755]
+16 Swamp

--- a/data/welcome/sos/Black Deck.txt
+++ b/data/welcome/sos/Black Deck.txt
@@ -2,24 +2,24 @@
 // SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
 // DATE: 2026-04-24
 1 Vampire Interloper [FDN:756]
-2 Gutless Plunderer
-2 Eaten Alive
-1 Vampire Neonate
-1 Vampire Gourmand
-2 Hero's Downfall
-1 Stromkirk Bloodthief
+2 Gutless Plunderer [FDN:60]
+2 Eaten Alive [FDN:172]
+1 Vampire Neonate [FDN:531]
+1 Vampire Gourmand [FDN:74]
+2 Hero's Downfall [FDN:175]
+1 Stromkirk Bloodthief [FDN:185]
 1 Vampire Soulcaller [FDN:758]
-1 Crossway Troublemakers
+1 Crossway Troublemakers [FDN:518]
 1 Vampire Nighthawk [FDN:757]
 1 Kalastria Highborn [FDN:753]
-1 Zombify
-1 Macabre Waltz
-1 Vengeful Bloodwitch
-1 Vampire Spawn
+1 Zombify [FDN:187]
+1 Macabre Waltz [FDN:177]
+1 Vengeful Bloodwitch [FDN:76]
+1 Vampire Spawn [FDN:532]
 1 Massacre Wurm [FDN:754]
 1 Bloodtithe Collector [FDN:751]
-1 Rogue's Passage
+1 Rogue's Passage [FDN:264]
 1 Gatekeeper of Malakir [FDN:752]
-1 Sanguine Syphoner
+1 Sanguine Syphoner [FDN:68]
 1 Pulse Tracker [FDN:755]
-16 Swamp
+16 Swamp [FDN:276]

--- a/data/welcome/sos/Blue Deck.txt
+++ b/data/welcome/sos/Blue Deck.txt
@@ -3,22 +3,22 @@
 // DATE: 2026-04-24
 2 Kitesail Corsair [FDN:743]
 1 Spectral Sailor [FDN:746]
-2 Starlight Snare
-2 Refute
-1 Think Twice
-1 Uncharted Voyage
+2 Starlight Snare [FDN:514]
+2 Refute [FDN:48]
+1 Think Twice [FDN:165]
+1 Uncharted Voyage [FDN:53]
 1 Sphinx of the Final Word [FDN:747]
 2 Icewind Elemental [FDN:742]
-1 Storm Fleet Spy
-1 Aetherize
-1 Bigfin Bouncer
+1 Storm Fleet Spy [FDN:515]
+1 Aetherize [FDN:151]
+1 Bigfin Bouncer [FDN:31]
 1 Rune-Sealed Wall [FDN:745]
 1 Tempest Djinn [FDN:749]
 1 Cryptic Caves [FDN:771]
 1 Arcanis the Omnipotent [FDN:741]
 1 Unsummon [FDN:750]
 1 Mocking Sprite [FDN:744]
-1 Quick Study
+1 Quick Study [FDN:513]
 1 Strix Lookout [FDN:748]
-1 Aegis Turtle
-16 Island
+1 Aegis Turtle [FDN:150]
+16 Island [FDN:274]

--- a/data/welcome/sos/Blue Deck.txt
+++ b/data/welcome/sos/Blue Deck.txt
@@ -1,0 +1,24 @@
+// NAME: Blue Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
+// DATE: 2026-04-24
+2 Kitesail Corsair [FDN:743]
+1 Spectral Sailor [FDN:746]
+2 Starlight Snare
+2 Refute
+1 Think Twice
+1 Uncharted Voyage
+1 Sphinx of the Final Word [FDN:747]
+2 Icewind Elemental [FDN:742]
+1 Storm Fleet Spy
+1 Aetherize
+1 Bigfin Bouncer
+1 Rune-Sealed Wall [FDN:745]
+1 Tempest Djinn [FDN:749]
+1 Cryptic Caves [FDN:771]
+1 Arcanis the Omnipotent [FDN:741]
+1 Unsummon [FDN:750]
+1 Mocking Sprite [FDN:744]
+1 Quick Study
+1 Strix Lookout [FDN:748]
+1 Aegis Turtle
+16 Island

--- a/data/welcome/sos/Green Deck.txt
+++ b/data/welcome/sos/Green Deck.txt
@@ -1,24 +1,24 @@
 // NAME: Green Deck
 // SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
 // DATE: 2026-04-24
-2 Llanowar Elves
-2 Thrashing Brontodon
-1 Mild-Mannered Librarian
-2 Bite Down
-1 Wary Thespian
-1 Magnigoth Sentry
+2 Llanowar Elves [FDN:227]
+2 Thrashing Brontodon [FDN:560]
+1 Mild-Mannered Librarian [FDN:228]
+2 Bite Down [FDN:212]
+1 Wary Thespian [FDN:235]
+1 Magnigoth Sentry [FDN:556]
 1 Springbloom Druid [FDN:767]
 1 Pelakka Wurm [FDN:765]
-1 Elvish Regrower
-1 Blanchwood Armor
+1 Elvish Regrower [FDN:104]
+1 Blanchwood Armor [FDN:213]
 1 Primal Might [FDN:766]
-1 Broken Wings
-1 Rogue's Passage
-1 Wildheart Invoker
-1 Thornweald Archer
+1 Broken Wings [FDN:214]
+1 Rogue's Passage [FDN:264]
+1 Wildheart Invoker [FDN:561]
+1 Thornweald Archer [FDN:559]
 1 Vizier of the Menagerie [FDN:769]
 1 Surrak, the Hunt Caller [FDN:768]
-1 Affectionate Indrik
-1 Bushwhack
-1 Treetop Snarespinner
-17 Forest
+1 Affectionate Indrik [FDN:211]
+1 Bushwhack [FDN:215]
+1 Treetop Snarespinner [FDN:114]
+17 Forest [FDN:280]

--- a/data/welcome/sos/Green Deck.txt
+++ b/data/welcome/sos/Green Deck.txt
@@ -1,0 +1,24 @@
+// NAME: Green Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
+// DATE: 2026-04-24
+2 Llanowar Elves
+2 Thrashing Brontodon
+1 Mild-Mannered Librarian
+2 Bite Down
+1 Wary Thespian
+1 Magnigoth Sentry
+1 Springbloom Druid [FDN:767]
+1 Pelakka Wurm [FDN:765]
+1 Elvish Regrower
+1 Blanchwood Armor
+1 Primal Might [FDN:766]
+1 Broken Wings
+1 Rogue's Passage
+1 Wildheart Invoker
+1 Thornweald Archer
+1 Vizier of the Menagerie [FDN:769]
+1 Surrak, the Hunt Caller [FDN:768]
+1 Affectionate Indrik
+1 Bushwhack
+1 Treetop Snarespinner
+17 Forest

--- a/data/welcome/sos/Red Deck.txt
+++ b/data/welcome/sos/Red Deck.txt
@@ -1,0 +1,21 @@
+// NAME: Red Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
+// DATE: 2026-04-24
+2 Burst Lightning
+1 Carnelian Orb of Dragonkind [FDN:759]
+2 Firespitter Whelp [FDN:761]
+2 Kargan Dragonrider [FDN:762]
+1 Drakuseth, Maw of Flames [FDN:760]
+2 Scorching Dragonfire
+1 Spitfire Lagac
+2 Incinerating Blast
+2 Dragonlord's Servant
+1 Cryptic Caves [FDN:771]
+1 Axgard Cavalry
+1 Terror of Mount Velus [FDN:764]
+1 Brazen Scourge
+1 Etali, Primal Storm
+1 Skyraker Giant
+1 Shivan Dragon [FDN:763]
+1 Fanatical Firebrand
+17 Mountain

--- a/data/welcome/sos/Red Deck.txt
+++ b/data/welcome/sos/Red Deck.txt
@@ -1,21 +1,21 @@
 // NAME: Red Deck
 // SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
 // DATE: 2026-04-24
-2 Burst Lightning
+2 Burst Lightning [FDN:192]
 1 Carnelian Orb of Dragonkind [FDN:759]
 2 Firespitter Whelp [FDN:761]
 2 Kargan Dragonrider [FDN:762]
 1 Drakuseth, Maw of Flames [FDN:760]
-2 Scorching Dragonfire
-1 Spitfire Lagac
-2 Incinerating Blast
-2 Dragonlord's Servant
+2 Scorching Dragonfire [FDN:545]
+1 Spitfire Lagac [FDN:208]
+2 Incinerating Blast [FDN:90]
+2 Dragonlord's Servant [FDN:536]
 1 Cryptic Caves [FDN:771]
-1 Axgard Cavalry
+1 Axgard Cavalry [FDN:189]
 1 Terror of Mount Velus [FDN:764]
-1 Brazen Scourge
-1 Etali, Primal Storm
-1 Skyraker Giant
+1 Brazen Scourge [FDN:191]
+1 Etali, Primal Storm [FDN:194]
+1 Skyraker Giant [FDN:547]
 1 Shivan Dragon [FDN:763]
-1 Fanatical Firebrand
-17 Mountain
+1 Fanatical Firebrand [FDN:195]
+17 Mountain [FDN:278]

--- a/data/welcome/sos/White Deck.txt
+++ b/data/welcome/sos/White Deck.txt
@@ -2,15 +2,15 @@
 // SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
 // DATE: 2026-04-24
 2 Healer's Hawk [FDN:734]
-1 Ajani's Pridemate
-1 Joust Through
+1 Ajani's Pridemate [FDN:135]
+1 Joust Through [FDN:19]
 1 Prayer of Binding [FDN:739]
-2 Helpful Hunter
-1 Bishop's Soldier
+2 Helpful Hunter [FDN:16]
+1 Bishop's Soldier [FDN:491]
 1 Serra Angel [FDN:740]
 1 Herald of Faith [FDN:735]
-1 Pacifism
-1 Cathar Commando
+1 Pacifism [FDN:501]
+1 Cathar Commando [FDN:139]
 1 Inspiring Overseer [FDN:736]
 1 Crusader of Odric [FDN:731]
 1 Dazzling Angel [FDN:732]
@@ -18,9 +18,9 @@
 1 Cryptic Caves [FDN:771]
 1 Lyra Dawnbringer [FDN:738]
 1 Linden, the Steadfast Queen [FDN:737]
-1 Dauntless Veteran
-1 Moment of Triumph
-1 Banishing Light
+1 Dauntless Veteran [FDN:8]
+1 Moment of Triumph [FDN:500]
+1 Banishing Light [FDN:138]
 1 Diamond Mare [FDN:770]
-1 Hinterland Sanctifier
-16 Plains
+1 Hinterland Sanctifier [FDN:730]
+16 Plains [FDN:272]

--- a/data/welcome/sos/White Deck.txt
+++ b/data/welcome/sos/White Deck.txt
@@ -1,0 +1,26 @@
+// NAME: White Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven
+// DATE: 2026-04-24
+2 Healer's Hawk [FDN:734]
+1 Ajani's Pridemate
+1 Joust Through
+1 Prayer of Binding [FDN:739]
+2 Helpful Hunter
+1 Bishop's Soldier
+1 Serra Angel [FDN:740]
+1 Herald of Faith [FDN:735]
+1 Pacifism
+1 Cathar Commando
+1 Inspiring Overseer [FDN:736]
+1 Crusader of Odric [FDN:731]
+1 Dazzling Angel [FDN:732]
+1 Exemplar of Light [FDN:733]
+1 Cryptic Caves [FDN:771]
+1 Lyra Dawnbringer [FDN:738]
+1 Linden, the Steadfast Queen [FDN:737]
+1 Dauntless Veteran
+1 Moment of Triumph
+1 Banishing Light
+1 Diamond Mare [FDN:770]
+1 Hinterland Sanctifier
+16 Plains

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -415,7 +415,7 @@ welcome:
   format: "casual"
   name: "Welcome Deck"
   sections:
-    Main Deck: 30
+    Main Deck: [30, 40]
 welcome-std:
   category: "deck"
   format: "casual standard"


### PR DESCRIPTION
## Summary

Adds the five **Secrets of Strixhaven Welcome Decks** (released 2026-04-24). Despite shipping with SOS, their cards are Foundations reprints — and **41 of them are new prints with unique collector numbers, FDN #731–771** (mostly reminder-text updates). Those printings had no product mapping and showed as `is:productless` (`s:FDN date:2026-04-24`).

The announcement's deck-list widget declares `set="FDN"` for every deck, so **every card is tagged with its explicit `[FDN:###]` printing** — the 41 renumbered cards to #731–771, the rest to their main-set Foundations number (basics to FDN basics).

| Deck | Renumbered cards |
|---|---|
| White | FDN #731–740, #770 (Diamond Mare), #771 (Cryptic Caves) |
| Blue | FDN #741–750, #771 |
| Black | FDN #751–758 |
| Red | FDN #759–764, #771 |
| Green | FDN #765–769 |

(Cryptic Caves #771 is shared across the White/Blue/Red decks.)

## Deck-type change

`welcome` deck type extended from `Main Deck: 30` to `Main Deck: [30, 40]` — these newer Welcome Decks are 40 cards. The existing 30-card decks still validate.

## Verification

Built `decks.json` (clean, no warnings; all five decks 40/40 cards, every line resolved to an explicit set+number) and ran the productless checker against the search-engine index:

| group | before | after |
|---|---|---|
| FDN nonfoil | 41 | 0 |

The one remaining FDN foil productless (#728 Phyrexian Arena) is pre-existing and unrelated — it isn't part of the 2026-04-24 batch, and Welcome Deck cards are all nonfoil.

## Note for review

The announcement pins basic-land art via opaque internal IDs (not collector numbers), so basics are tagged with the standard FDN basics rather than the exact pinned art. For multi-printing non-basics, the main-set FDN number is used. None of this affects productless resolution (only the #731–771 prints were productless).

Sources: [WotC — New Welcome Decks Arrive with Secrets of Strixhaven](https://magic.wizards.com/en/news/announcements/new-welcome-decks-arrive-with-secrets-of-strixhaven), [MTG Wiki — Secrets of Strixhaven/Welcome decks](https://mtg.wiki/page/Secrets_of_Strixhaven/Welcome_decks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)