### PR TITLE
Add Theros Beyond Death bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/thb/Theros Beyond Death Bundle Land Pack.txt
+++ b/data/bundle-land-pack/thb/Theros Beyond Death Bundle Land Pack.txt
@@ -1,0 +1,23 @@
+// NAME: Theros Beyond Death Bundle Land Pack
+// SOURCE: https://mtg.wiki/page/Theros_Beyond_Death
+// DATE: 2020-01-24
+2 Plains [THB:278]
+2 Plains [THB:279]
+2 Plains [THB:278] [foil]
+2 Plains [THB:279] [foil]
+2 Island [THB:280]
+2 Island [THB:281]
+2 Island [THB:280] [foil]
+2 Island [THB:281] [foil]
+2 Swamp [THB:282]
+2 Swamp [THB:283]
+2 Swamp [THB:282] [foil]
+2 Swamp [THB:283] [foil]
+2 Mountain [THB:284]
+2 Mountain [THB:285]
+2 Mountain [THB:284] [foil]
+2 Mountain [THB:285] [foil]
+2 Forest [THB:286]
+2 Forest [THB:287]
+2 Forest [THB:286] [foil]
+2 Forest [THB:287] [foil]


### PR DESCRIPTION
Models the **Theros Beyond Death Bundle** basic lands (foil #278-287), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck listing the bundle's foil + nonfoil basics, matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)