### PR TITLE
Add Zendikar Rising bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/znr/Zendikar Rising Bundle Land Pack.txt
+++ b/data/bundle-land-pack/znr/Zendikar Rising Bundle Land Pack.txt
@@ -1,0 +1,13 @@
+// NAME: Zendikar Rising Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-zendikar-rising-2020-09-01
+// DATE: 2020-09-25
+4 Plains [ZNR:380]
+4 Plains [ZNR:380] [foil]
+4 Island [ZNR:381]
+4 Island [ZNR:381] [foil]
+4 Swamp [ZNR:382]
+4 Swamp [ZNR:382] [foil]
+4 Mountain [ZNR:383]
+4 Mountain [ZNR:383] [foil]
+4 Forest [ZNR:384]
+4 Forest [ZNR:384] [foil]


### PR DESCRIPTION
Models the **Zendikar Rising Bundle** basic lands (foil #380-384), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck listing the bundle's foil + nonfoil basics, matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)