### PR TITLE
Add Kaldheim bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/khm/Kaldheim Bundle Land Pack.txt
+++ b/data/bundle-land-pack/khm/Kaldheim Bundle Land Pack.txt
@@ -1,0 +1,13 @@
+// NAME: Kaldheim Bundle Land Pack
+// SOURCE: https://mtg.wiki/page/Kaldheim
+// DATE: 2021-02-05
+4 Plains [KHM:394]
+4 Plains [KHM:394] [foil]
+4 Island [KHM:395]
+4 Island [KHM:395] [foil]
+4 Swamp [KHM:396]
+4 Swamp [KHM:396] [foil]
+4 Mountain [KHM:397]
+4 Mountain [KHM:397] [foil]
+4 Forest [KHM:398]
+4 Forest [KHM:398] [foil]


### PR DESCRIPTION
Models the **Kaldheim Bundle** basic lands (foil #394-398), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck listing the bundle's foil + nonfoil basics, matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)