### PR TITLE
Add Innistrad: Midnight Hunt bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/mid/Innistrad- Midnight Hunt Bundle Land Pack.txt
+++ b/data/bundle-land-pack/mid/Innistrad- Midnight Hunt Bundle Land Pack.txt
@@ -1,0 +1,13 @@
+// NAME: Innistrad: Midnight Hunt Bundle Land Pack
+// SOURCE: https://mtg.wiki/page/Innistrad:_Midnight_Hunt
+// DATE: 2021-09-24
+4 Plains [MID:380]
+4 Plains [MID:380] [foil]
+4 Island [MID:381]
+4 Island [MID:381] [foil]
+4 Swamp [MID:382]
+4 Swamp [MID:382] [foil]
+4 Mountain [MID:383]
+4 Mountain [MID:383] [foil]
+4 Forest [MID:384]
+4 Forest [MID:384] [foil]


### PR DESCRIPTION
Models the **Innistrad: Midnight Hunt Bundle** basic lands (foil #380-384), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck listing the bundle's foil + nonfoil basics, matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)