### PR TITLE
Add Guilds of Ravnica bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/grn/Guilds of Ravnica Bundle Land Pack.txt
+++ b/data/bundle-land-pack/grn/Guilds of Ravnica Bundle Land Pack.txt
@@ -1,0 +1,13 @@
+// NAME: Guilds of Ravnica Bundle Land Pack
+// SOURCE: https://mtg.wiki/page/Guilds_of_Ravnica
+// DATE: 2018-10-05
+4 Plains [GRN:260]
+4 Plains [GRN:260] [foil]
+4 Island [GRN:261]
+4 Island [GRN:261] [foil]
+4 Swamp [GRN:262]
+4 Swamp [GRN:262] [foil]
+4 Mountain [GRN:263]
+4 Mountain [GRN:263] [foil]
+4 Forest [GRN:264]
+4 Forest [GRN:264] [foil]


### PR DESCRIPTION
Models the **Guilds of Ravnica Bundle** basic lands (#260-264), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck listing the bundle's foil + nonfoil basics, matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)