### PR TITLE
Add Ravnica Allegiance bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/rna/Ravnica Allegiance Bundle Land Pack.txt
+++ b/data/bundle-land-pack/rna/Ravnica Allegiance Bundle Land Pack.txt
@@ -1,0 +1,13 @@
+// NAME: Ravnica Allegiance Bundle Land Pack
+// SOURCE: https://mtg.wiki/page/Ravnica_Allegiance
+// DATE: 2019-01-25
+4 Plains [RNA:260]
+4 Plains [RNA:260] [foil]
+4 Island [RNA:261]
+4 Island [RNA:261] [foil]
+4 Swamp [RNA:262]
+4 Swamp [RNA:262] [foil]
+4 Mountain [RNA:263]
+4 Mountain [RNA:263] [foil]
+4 Forest [RNA:264]
+4 Forest [RNA:264] [foil]


### PR DESCRIPTION
Models the **Ravnica Allegiance Bundle** basic lands (#260-264), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck listing the bundle's foil + nonfoil basics, matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)