### PR TITLE
Add Marvel Super Heroes bundle land pack (resolve is:productless basics)

### DIFF
--- a/data/bundle-land-pack/msh/Marvel Super Heroes Bundle Land Pack.txt
+++ b/data/bundle-land-pack/msh/Marvel Super Heroes Bundle Land Pack.txt
@@ -1,0 +1,13 @@
+// NAME: Marvel Super Heroes Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-marvel-super-heroes
+// DATE: 2025-09-26
+3 Plains [MSH:433] [foil]
+3 Plains [MSH:434] [foil]
+3 Island [MSH:435] [foil]
+3 Island [MSH:436] [foil]
+3 Swamp [MSH:437] [foil]
+3 Swamp [MSH:438] [foil]
+3 Mountain [MSH:439] [foil]
+3 Mountain [MSH:440] [foil]
+3 Forest [MSH:441] [foil]
+3 Forest [MSH:442] [foil]


### PR DESCRIPTION
Models the **Marvel Super Heroes Bundle** basic lands (foil full-art #433-442), which had no product mapping and showed as `is:productless`. Adds a `bundle-land-pack` deck matching the existing `blb`/`fin`/`lci` convention.

Verified: productless basics for this set → 0 after rebuilding decks.json and running the search-engine productless check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)