### PR TITLE
Add the Theros-block Challenge Decks

### DIFF
--- a/data/challenge/tbth/Battle the Horde.txt
+++ b/data/challenge/tbth/Battle the Horde.txt
@@ -1,0 +1,18 @@
+// NAME: Battle the Horde
+// SOURCE: https://mtg.wiki/page/Battle_the_Horde
+// DATE: 2014-03-01
+10 Minotaur Goreseeker [TBTH:1] [token]
+15 Minotaur Younghorn [TBTH:2] [token]
+4 Mogis's Chosen [TBTH:3] [token]
+10 Phoberos Reaver [TBTH:4] [token]
+4 Reckless Minotaur [TBTH:5] [token]
+2 Consuming Rage [TBTH:6]
+2 Descend on the Prey [TBTH:7]
+2 Intervention of Keranos [TBTH:8]
+2 Touch of the Horned God [TBTH:9]
+2 Unquenchable Fury [TBTH:10]
+1 Altar of Mogis [TBTH:11]
+1 Massacre Totem [TBTH:12]
+2 Plundered Statue [TBTH:13]
+2 Refreshing Elixir [TBTH:14]
+1 Vitality Salve [TBTH:15]

--- a/data/challenge/tdag/Defeat a God.txt
+++ b/data/challenge/tdag/Defeat a God.txt
@@ -1,0 +1,18 @@
+// NAME: Defeat a God
+// SOURCE: https://mtg.wiki/page/Defeat_a_God
+// DATE: 2014-05-25
+1 Xenagos Ascended [TDAG:1] [token]
+6 Rollicking Throng [TDAG:2] [token]
+16 Ecstatic Piper [TDAG:3] [token]
+2 Maddened Oread [TDAG:4] [token]
+4 Pheres-Band Revelers [TDAG:5] [token]
+2 Serpent Dancers [TDAG:6] [token]
+2 Wild Maenads [TDAG:7] [token]
+7 Impulsive Charge [TDAG:8]
+2 Impulsive Destruction [TDAG:9]
+4 Impulsive Return [TDAG:10]
+2 Rip to Pieces [TDAG:11]
+3 Xenagos's Scorn [TDAG:12]
+5 Xenagos's Strike [TDAG:13]
+2 Dance of Flame [TDAG:14]
+2 Dance of Panic [TDAG:15]

--- a/data/challenge/tfth/Face the Hydra.txt
+++ b/data/challenge/tfth/Face the Hydra.txt
@@ -1,0 +1,18 @@
+// NAME: Face the Hydra
+// SOURCE: https://mtg.wiki/page/Face_the_Hydra
+// DATE: 2013-10-19
+11 Hydra Head [TFTH:1] [token]
+4 Ravenous Brute Head [TFTH:2] [token]
+1 Savage Vigor Head [TFTH:3] [token]
+1 Shrieking Titan Head [TFTH:4] [token]
+1 Snapping Fang Head [TFTH:5] [token]
+5 Disorienting Glower [TFTH:6]
+5 Distract the Hydra [TFTH:7]
+4 Grown from the Stump [TFTH:8]
+4 Hydra's Impenetrable Hide [TFTH:9]
+3 Neck Tangle [TFTH:10]
+4 Noxious Hydra Breath [TFTH:11]
+2 Strike the Weak Spot [TFTH:12]
+5 Swallow the Hero Whole [TFTH:13]
+4 Torn Between Heads [TFTH:14]
+6 Unified Lunge [TFTH:15]

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -78,6 +78,12 @@ bundle-land-pack:
   name: "Bundle Land Pack"
   sections:
     Main Deck: [30, 32, 40]
+challenge:
+  category: "deck"
+  format: null
+  name: "Challenge Deck"
+  sections:
+    Main Deck: [17, 27, 42]
 challenger:
   category: "deck"
   format: "standard"

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -82,6 +82,12 @@ challenge:
   category: "deck"
   format: null
   name: "Challenge Deck"
+  # Theros-block "Hero's Path" solo challenge decks (Battle the Horde / Defeat a
+  # God / Face the Hydra). Each holds 15 unique cards, but MTGJSON stores the
+  # creatures the hero fights (Hydra Head, the Minotaurs, Xenagos Ascended, ...)
+  # as tokens rather than cards. Those carry the [token] marker and are counted
+  # separately, so only the non-token challenge cards land in the Main Deck:
+  # Battle the Horde 17, Defeat a God 27, Face the Hydra 42.
   sections:
     Main Deck: [17, 27, 42]
 challenger:


### PR DESCRIPTION
Adds Face the Hydra, Battle the Horde, and Defeat a God — the Hero's Path challenge decks from the Theros-block Game Days — under a new `challenge` deck type.

Each is a 60-card deck built from 15 unique non-legal cards (mtgjson sets TFTH/TBTH/TDAG). The creature-type cards are classified as tokens by the card index, so they carry the `[token]` marker, and the deck type sizes the Main Deck on the remaining spell cards (42, 17, and 27 respectively).

Decklists follow the MTG Wiki pages ([Face the Hydra](https://mtg.wiki/page/Face_the_Hydra), [Battle the Horde](https://mtg.wiki/page/Battle_the_Horde), [Defeat a God](https://mtg.wiki/page/Defeat_a_God)), with names and collector numbers cross-checked against mtgjson. Every deck sums to 60 physical cards.

Motivation: mtgjson's mtg-sealed-content wants to reference these products' contents as decks, like the recently added Bundle Land Packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)