### PR TITLE
Add Marvel Super Heroes Welcome Decks (5 × 30-card)

### DIFF
--- a/data/welcome-std/msh/Black Deck.txt
+++ b/data/welcome-std/msh/Black Deck.txt
@@ -1,0 +1,17 @@
+// NAME: Black Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-welcome-decks
+// DATE: 2026-06-26
+1 Black Widow, Daring Operative [MSC:831]
+2 Songbird, Sonic Screamer [MSC:762]
+1 Tombstone, Career Criminal [MSC:160]
+1 Ultimo, Civilization's End [MSC:540]
+1 Unliving Legionnaire [MSH:119]
+2 Symbiote Spawn [SPE:11]
+2 Glamorous Grapplers [MSC:536]
+1 Infernal Rebirth [MSC:537]
+2 Red Room Recruit [MSH:110]
+1 Dark Deed [MSH:93]
+1 Hour of Defeat [MSH:99]
+1 Widow's Bite [MSH:122]
+1 Doom Blade [MSC:576]
+13 Swamp [MSH:281]

--- a/data/welcome-std/msh/Blue Deck.txt
+++ b/data/welcome-std/msh/Blue Deck.txt
@@ -1,0 +1,18 @@
+// NAME: Blue Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-welcome-decks
+// DATE: 2026-06-26
+1 Iron Man, Modern Marvel [MSC:830]
+1 Iron Lad, Diverging Destiny [MSH:59]
+1 Lyla, Holographic Assistant [SPE:7]
+1 Blue Marvel, Adam Brashear [MSC:530]
+1 Mist-Cloaked Herald [MSC:760]
+2 TVA Bureaucrat [MSC:761]
+2 Aerial Doombot [MSH:43]
+1 Futurist Forge [MSH:55]
+2 Alchemax Slayer-Bots [SPE:5]
+1 Whoosh! [MSC:790]
+1 Ant-Man's Air Force [MSC:759]
+1 A.I.M. Scientists [MSH:44]
+1 I Am Iron Man [MSH:58]
+1 Depower [MSH:50]
+13 Island [MSH:279]

--- a/data/welcome-std/msh/Green Deck.txt
+++ b/data/welcome-std/msh/Green Deck.txt
@@ -1,0 +1,19 @@
+// NAME: Green Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-welcome-decks
+// DATE: 2026-06-26
+1 Hulk, Brutal Brawler [MSC:833]
+1 She-Hulk, Jade Defender [MSH:188]
+1 Goliath, Mass Manipulator [MSC:766]
+1 Wolfsbane, Highland Hero [MSC:767]
+1 Mister Hyde, Monster Within [MSH:176]
+2 The Fabulous Frog-Man [MSC:559]
+2 Undercover Skrull [MSH:194]
+1 Savage Land Dinosaur [MSH:185]
+1 Wakandan Royal Guard [MSH:195]
+1 Kapow! [SPM:103]
+1 Super Strength [MSH:189]
+1 Warriors of Wakanda [MSC:565]
+1 Giant Growth [MSH:167]
+1 Thing Swing [MSC:564]
+1 Knight of Wundagore [MSH:175]
+13 Forest [MSH:285]

--- a/data/welcome-std/msh/Red Deck.txt
+++ b/data/welcome-std/msh/Red Deck.txt
@@ -1,0 +1,19 @@
+// NAME: Red Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-welcome-decks
+// DATE: 2026-06-26
+1 Spider-Man, Web-Spinner [MSC:832]
+1 Human Torch, Johnny Storm [MSH:136]
+1 Misty Knight, Hero for Hire [MSH:145]
+1 Living Lightning, Charged Up [MSC:764]
+1 Quicksilver, Pietro Maximoff [MSC:551]
+1 Happy Hogan, Dauntless Driver [MSC:545]
+2 Rampaging Classmate [SPE:16]
+2 Extremis Elite [MSC:763]
+1 Kree Sentinel [MSH:141]
+1 Sif's Spearmaster [MSC:765]
+1 Furious Strength [MSC:544]
+1 Marvelous Melee [MSC:549]
+1 The Mary Janes [SPE:15]
+1 Smashing Spree [MSC:555]
+1 Lightning Strike [MSH:142]
+13 Mountain [MSH:283]

--- a/data/welcome-std/msh/White Deck.txt
+++ b/data/welcome-std/msh/White Deck.txt
@@ -1,0 +1,19 @@
+// NAME: White Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-welcome-decks
+// DATE: 2026-06-26
+1 Black Panther, Claws of Bast [MSC:829]
+1 Peggy Carter, Secret Agent [MSC:523]
+1 Mockingbird, Bobbi Morse [MSC:522]
+1 Doctor Jane Foster [MSC:757]
+2 Virtuous Variant [MSC:758]
+1 Valkyrior Skyrider [MSC:525]
+1 Selfless Police Captain [MSC:774]
+1 Fall to Earth [MSC:517]
+1 Luke Cage, Power Man [MSH:20]
+1 Raft Security Officer [MSH:33]
+2 Brave Brawler [MSH:8]
+1 Crowd of True Believers [MSH:14]
+1 Vibranium Energy Daggers [MSH:254]
+1 Take Up the Shield [MSH:39]
+1 Web Up [MSH:41]
+13 Plains [MSH:277]


### PR DESCRIPTION
The five MSH Welcome Decks from the [announcement](https://magic.wizards.com/en/news/announcements/marvel-super-heroes-welcome-decks) — White/Blue/Black/Red/Green, 30 cards each.

**Note on set spread:** these welcome decks pull reprints across the Marvel block. Each is mostly `msh` (main) + `msc` (Commander), but a handful of cards only exist in the Spider-Man sets and are tagged accordingly:
- Blue (Iron Man): `Lyla, Holographic Assistant` [SPE:7], `Alchemax Slayer-Bots` [SPE:5]
- Black (Widow): `Symbiote Spawn` [SPE:11]
- Red (Spider-Man): `Rampaging Classmate` [SPE:16], `The Mary Janes` [SPE:15]
- Green (Hulk): `Kapow!` [SPM:103]

Every card is tagged `[SET:num]` and validated against the card data; counts are exactly 30. One extraction gotcha handled: `Selfless Police Captain` (msc 774) is one card, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)