### PR TITLE
Add Marvel Super Heroes Scene Box cards (Heroes United, Villains Unleashed)

### DIFF
--- a/data/box/msh/Heroes United.txt
+++ b/data/box/msh/Heroes United.txt
@@ -1,0 +1,10 @@
+// NAME: Heroes United
+// SOURCE: https://magic.wizards.com/en/news/feature/assemble-the-scenes-of-marvel-super-heroes
+// DATE: 2026-06-26
+// DISPLAY: Marvel Super Heroes Scene Box - Heroes United - 6 traditional foil borderless scene cards
+1 Iron Man, Futurist Paragon [MSC:501] [foil]
+1 Hulk, Always Angry [MSC:502] [foil]
+1 Thor, Guardian of Midgard [MSC:503] [foil]
+1 Black Widow, Intel Expert [MSC:504] [foil]
+1 Captain America, Unbowed [MSC:505] [foil]
+1 Hawkeye, Trick Shot [MSC:506] [foil]

--- a/data/box/msh/Villains Unleashed.txt
+++ b/data/box/msh/Villains Unleashed.txt
@@ -1,0 +1,10 @@
+// NAME: Villains Unleashed
+// SOURCE: https://magic.wizards.com/en/news/feature/assemble-the-scenes-of-marvel-super-heroes
+// DATE: 2026-06-26
+// DISPLAY: Marvel Super Heroes Scene Box - Villains Unleashed - 6 traditional foil borderless scene cards
+1 Ultron, Machine Overlord [MSC:507] [foil]
+1 Thanos, Death's Consort [MSC:508] [foil]
+1 M.O.D.O.K., Evil Intellect [MSC:509] [foil]
+1 Absorbing Man and Titania [MSC:510] [foil]
+1 Abomination, Irradiated Brute [MSC:511] [foil]
+1 Loki, God of Lies [MSC:512] [foil]


### PR DESCRIPTION
The two MSH Scene Boxes, each **6 traditional-foil borderless scene cards** that tile into one scene (per the [Assemble the Scenes](https://magic.wizards.com/en/news/feature/assemble-the-scenes-of-marvel-super-heroes) feature + card-list sources). They're consecutive borderless printings in the Commander set:

- **Heroes United** — msc 501-506: Iron Man, Futurist Paragon / Hulk, Always Angry / Thor, Guardian of Midgard / Black Widow, Intel Expert / Captain America, **Unbowed** / Hawkeye, Trick Shot
- **Villains Unleashed** — msc 507-512: Ultron, Machine Overlord / Thanos, Death's Consort / M.O.D.O.K., Evil Intellect / Absorbing Man and Titania / Abomination, Irradiated Brute / Loki, God of Lies

Modeled on the Final Fantasy scene boxes. All 12 verified against the card data (one secondary source listed "Captain America, Unbound" — the real card is **Unbowed**, msc 505).

🤖 Generated with [Claude Code](https://claude.com/claude-code)