### PR TITLE
Add Marvel Super Heroes Beginner Box half-decks (10 × 20-card)

### DIFF
--- a/data/box/msh/Beginner Box - Artifacts.txt
+++ b/data/box/msh/Beginner Box - Artifacts.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Artifacts
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Aerial Doombot [MSH:43]
+1 Hydraulic Helper [MSH:57]
+1 S.H.I.E.L.D. Deployment Drone [MSH:73]
+1 Ultron Drone [MSH:253]
+1 A.I.M. Bot [MSC:529]
+1 Victor Mancha, Runaway [MSC:574]
+1 War Machine, James Rhodes [MSC:572]
+1 Repulsor Bots [MSC:532]
+1 Vibranium Energy Daggers [MSH:254]
+1 Futurist Forge [MSH:55]
+1 Thirst for Knowledge [MSH:79]
+1 Frozen in Ice [MSH:54]
+7 Island [MSH:279]
+1 Thriving Isle [MSC:581]

--- a/data/box/msh/Beginner Box - Captain America Tutorial.txt
+++ b/data/box/msh/Beginner Box - Captain America Tutorial.txt
@@ -1,0 +1,16 @@
+// NAME: Beginner Box - Captain America Tutorial
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Hawkeye's Shot [MSC:839]
+1 Hero in Training [MSH:16]
+1 Soldier On [MSC:843]
+1 Mockingbird, Bobbi Morse [MSC:522]
+1 Ant-Man, Scott Lang [MSC:834]
+1 Captain America, Steve Rogers [MSC:835]
+1 Captain's Defense [MSC:836]
+1 The Falcon, Sam Wilson [MSC:837]
+1 Hawkeye, Clint Barton [MSC:518]
+1 The Wasp, Janet Van Dyne [MSC:844]
+8 Plains [MSH:277]
+1 Mandroid Squadron [MSC:841]
+1 Winter Soldier, Bucky Barnes [MSC:845]

--- a/data/box/msh/Beginner Box - Card Draw.txt
+++ b/data/box/msh/Beginner Box - Card Draw.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Card Draw
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 A.I.M. Bot [MSC:529]
+1 Brawn, Amadeus Cho [MSC:567]
+1 Bold Biochemist [MSH:48]
+1 Atlantean Cavalry [MSH:45]
+1 Graviton, Fundamental Force [MSC:531]
+1 Blue Marvel, Adam Brashear [MSC:530]
+1 A.I.M. Scientists [MSH:44]
+1 Super Intelligence [MSH:77]
+1 H.E.R.B.I.E. Scout Unit [MSH:247]
+1 Depower [MSH:50]
+1 Trickster's Stratagem [MSH:81]
+1 Stark's Ingenuity [MSC:533]
+7 Island [MSH:279]
+1 Thriving Isle [MSC:581]

--- a/data/box/msh/Beginner Box - Counters.txt
+++ b/data/box/msh/Beginner Box - Counters.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Counters
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Serpent Specialist [MSH:186]
+1 Knight of Wundagore [MSH:175]
+1 Hellcat, Undying Vigilante [MSH:170]
+1 Gamma Grotesque [MSC:562]
+1 Warriors of Wakanda [MSC:565]
+1 Mister Hyde, Monster Within [MSH:176]
+1 Beast, Erudite Aerialist [MSH:206]
+1 The Thing, Ben Grimm [MSH:190]
+1 Feral Ferocity [MSC:560]
+1 Punishing Punch [MSH:180]
+1 Training Regimen [MSH:192]
+1 Colossal Collision [MSC:558]
+7 Forest [MSH:285]
+1 Thriving Grove [MSC:579]

--- a/data/box/msh/Beginner Box - HYDRA.txt
+++ b/data/box/msh/Beginner Box - HYDRA.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - HYDRA
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Project Deathlok Soldier [MSH:109]
+1 Doom's Servo-Guards [MSC:535]
+1 Agents of HYDRA [MSH:85]
+1 HYDRA Troopers [MSH:101]
+1 Kingpin's Enforcers [MSH:102]
+1 Glamorous Grapplers [MSC:536]
+1 Arnim Zola, Bio-Fanatic [MSH:86]
+1 Madame Hydra, Reanimated [MSC:538]
+1 Ultimo, Civilization's End [MSC:540]
+1 Doom Blade [MSC:576]
+1 Infernal Rebirth [MSC:537]
+1 HYDRA Infiltration [MSH:100]
+7 Swamp [MSH:281]
+1 Thriving Moor [MSC:582]

--- a/data/box/msh/Beginner Box - Heroes.txt
+++ b/data/box/msh/Beginner Box - Heroes.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Heroes
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Agent of Atlas [MSH:3]
+1 Peggy Carter, Secret Agent [MSC:523]
+1 Brave Brawler [MSH:8]
+1 Agents of S.H.I.E.L.D. [MSH:5]
+1 Hero in Training [MSH:16]
+1 Hawkeye, Clint Barton [MSC:518]
+1 Okoye, Dora Milaje Leader [MSH:27]
+1 Valkyrior Skyrider [MSC:525]
+1 Wondrous Revival [MSC:528]
+1 Iconic Shield [MSC:520]
+1 Fall to Earth [MSC:517]
+1 Pacifism [MSC:575]
+1 Thriving Heath [MSC:580]
+7 Plains [MSH:277]

--- a/data/box/msh/Beginner Box - Iron Man Tutorial.txt
+++ b/data/box/msh/Beginner Box - Iron Man Tutorial.txt
@@ -1,0 +1,16 @@
+// NAME: Beginner Box - Iron Man Tutorial
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+8 Mountain [MSH:283]
+1 Smashing Spree [MSC:555]
+1 Concentrated Fire [MSC:847]
+1 Crimson Operative [MSH:126]
+1 Power Boost [MSC:852]
+1 Hulk, Bruce Banner [MSC:850]
+1 Iron Man, Tony Stark [MSC:851]
+1 Spider-Man, Hometown Hero [MSC:857]
+1 Scarlet Witch, Wanda Maximoff [MSC:855]
+1 Repulsor Rays [MSC:854]
+1 Quicksilver, Pietro Maximoff [MSC:551]
+1 Black Widow, Natasha Romanoff [MSC:846]
+1 Happy Hogan, Dauntless Driver [MSC:545]

--- a/data/box/msh/Beginner Box - Ramp.txt
+++ b/data/box/msh/Beginner Box - Ramp.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Ramp
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Undercover Skrull [MSH:194]
+1 Moon-Boy, Dino Rider [MSC:563]
+1 Gert and Old Lace, Runaways [MSC:568]
+1 The Fabulous Frog-Man [MSC:559]
+1 Warriors of Wakanda [MSC:565]
+1 Atlas, Sizable Stooge [MSC:566]
+1 Wakandan Royal Guard [MSH:195]
+1 Savage Land Dinosaur [MSH:185]
+1 Flora Colossus [MSC:561]
+1 Team Transmitter [MSC:573]
+1 Thing Swing [MSC:564]
+1 Colossal Collision [MSC:558]
+7 Forest [MSH:285]
+1 Thriving Grove [MSC:579]

--- a/data/box/msh/Beginner Box - Villains.txt
+++ b/data/box/msh/Beginner Box - Villains.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Villains
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Red Room Recruit [MSH:110]
+1 Boomerang, Blade Flinger [MSC:534]
+1 Ninja of the Hand [MSH:108]
+1 Baron Strucker, HYDRA Overlord [MSH:88]
+1 Tombstone, Career Criminal [MSC:160]
+1 Crossbones, Malicious Mercenary [MSH:91]
+1 Glamorous Grapplers [MSC:536]
+1 Roxxon Brutes [MSH:113]
+1 Minotaur, Roxxon CEO [MSC:539]
+1 Dark Deed [MSH:93]
+1 Visions of Villainy [MSH:120]
+1 Hour of Defeat [MSH:99]
+7 Swamp [MSH:281]
+1 Thriving Moor [MSC:582]

--- a/data/box/msh/Beginner Box - Young Avengers.txt
+++ b/data/box/msh/Beginner Box - Young Avengers.txt
@@ -1,0 +1,17 @@
+// NAME: Beginner Box - Young Avengers
+// SOURCE: https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents
+// DATE: 2026-06-26
+1 Speed, Young Avenger [MSH:152]
+1 Stature, Young Avenger [MSC:571]
+1 Patriot, Young Avenger [MSC:570]
+1 Iron Lad, Young Avenger [MSC:569]
+1 Wiccan, Young Avenger [MSC:557]
+1 She-Hulk, Jennifer Walters [MSC:554]
+1 The Immortal Weapons [MSC:547]
+1 Lightning Strike [MSH:142]
+1 Experimental Armor [MSC:543]
+1 Hire a Crew [MSH:134]
+1 Furious Strength [MSC:544]
+1 Marvelous Melee [MSC:549]
+7 Mountain [MSH:283]
+1 Thriving Bluff [MSC:578]


### PR DESCRIPTION
The ten themed Jumpstart half-decks from the [MSH Beginner Box](https://magic.wizards.com/en/news/announcements/marvel-super-heroes-beginner-box-contents): Heroes, Captain America Tutorial, Artifacts, Card Draw, HYDRA, Villains, Iron Man Tutorial, Young Avengers, Counters, Ramp — 20 cards each (200 total).

Modeled on the TLA Beginner Box decks (`data/box/<set>/Beginner Box - …`). Cards span `msh` + `msc`; every card tagged `[SET:num]` and validated against the card data (`om1` online-only printings excluded).

Handled one WotC-decklist gotcha: **`Project Deathlok Soldier`** (msh 109) is a single card — it was being split into "Project Deathlok" + "Soldier", same as `Selfless Police Captain` in the welcome decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)