### PR TITLE
tla: annotate cross-set (TLE) cards in the Beginner Box decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ To add new decks from new set:
 * use `bundle exec bin/validate_card_names` to validate card names
 
 CI will do validation for you if you open a PR.
+
+### Card set annotations
+
+Every card that comes from a set **different from the deck's own set** must be
+annotated with `[SETCODE]` (or `[SETCODE:number]` when a specific printing is
+needed); a trailing `[foil]` may follow. Cards from the deck's own set need no
+annotation. For example, an Avatar Eternal (`TLE`) card inside an Avatar (`TLA`)
+deck is written `1 Thriving Heath [TLE]`. The set-only form is enough when the
+card has a single printing in that set. The indexer can sometimes infer a
+cross-set printing on its own, but annotating it explicitly is required — it
+otherwise errors (`No Standard legal printing found`) or silently guesses.

--- a/data/box/tla/Beginner Box - Allies.txt
+++ b/data/box/tla/Beginner Box - Allies.txt
@@ -1,7 +1,7 @@
 // NAME: Beginner Box - Allies
 // SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
 // DATE: 2025-11-14
-1 Kyoshi Warrior Guard
+1 Kyoshi Warrior Guard [TLE]
 1 Jeong Jeong's Deserters
 1 Glider Kids
 1 Avatar Enthusiasts
@@ -10,7 +10,7 @@
 1 Suki, Kyoshi Warrior
 1 Rabaroo Troop
 1 Master Piandao
-1 Mechanical Glider
+1 Mechanical Glider [TLE]
 1 Path to Redemption
 1 Airbending Lesson
 1 Thriving Heath [TLE]

--- a/data/box/tla/Beginner Box - Attacking.txt
+++ b/data/box/tla/Beginner Box - Attacking.txt
@@ -1,11 +1,11 @@
 // NAME: Beginner Box - Attacking
 // SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
 // DATE: 2025-11-14
-1 Purple Pentapus
+1 Purple Pentapus [TLE]
 1 Corrupt Court Official
 1 Merchant of Many Hats
 1 Pretending Poxbearers
-1 Fire Nation Ambushers
+1 Fire Nation Ambushers [TLE]
 1 Hei Bai, Spirit of Balance
 1 Lion Vulture [TLE:232]
 1 Beetle-Headed Merchants

--- a/data/box/tla/Beginner Box - Big Creatures.txt
+++ b/data/box/tla/Beginner Box - Big Creatures.txt
@@ -3,14 +3,14 @@
 // DATE: 2025-11-14
 1 Turtle-Duck
 1 Raucous Audience
-1 Frog-Squirrels
+1 Frog-Squirrels [TLE]
 1 Ostrich-Horse
-1 Match the Odds
-1 Eel-Hounds
-1 Hippo-Cows
+1 Match the Odds [TLE]
+1 Eel-Hounds [TLE]
+1 Hippo-Cows [TLE]
 1 Saber-Tooth Moose-Lion
 1 Flopsie, Bumi's Buddy
-1 Mechanical Glider
+1 Mechanical Glider [TLE]
 1 Hog-Monkey Rampage [TLE:255]
 1 Seismic Tutelage [TLE:254]
 1 Thriving Grove [TLE]

--- a/data/box/tla/Beginner Box - Counters.txt
+++ b/data/box/tla/Beginner Box - Counters.txt
@@ -1,8 +1,8 @@
 // NAME: Beginner Box - Counters
 // SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
 // DATE: 2025-11-14
-1 Gilacorn
-1 Elephant-Rat
+1 Gilacorn [TLE]
+1 Elephant-Rat [TLE]
 1 Long Feng, Grand Secretariat
 1 Dai Li Indoctrination
 1 Fire Nation Engineer

--- a/data/box/tla/Beginner Box - Firebending.txt
+++ b/data/box/tla/Beginner Box - Firebending.txt
@@ -5,13 +5,13 @@
 1 Fire Sages
 1 Yuyan Archers
 1 Vindictive Warden
-1 Loyal Fire Sage
+1 Loyal Fire Sage [TLE]
 1 Zuko, Exiled Prince
 1 Fire Nation Archers [TLE:237]
 1 Rough Rhino Cavalry
 1 Mongoose Lizard
 1 Lightning Strike
 1 How to Start a Riot
-1 Roku's Mastery
+1 Roku's Mastery [TLE]
 1 Thriving Bluff [TLE]
 7 Mountain

--- a/data/box/tla/Beginner Box - Spells.txt
+++ b/data/box/tla/Beginner Box - Spells.txt
@@ -5,13 +5,13 @@
 1 Master Pakku
 1 Rowdy Snowballers
 1 Iguana Parrot
-1 Turtle-Seals
+1 Turtle-Seals [TLE]
 1 Geyser Leaper
 1 Serpent of the Pass
 1 Barrels of Blasting Jelly
 1 Abandon Attachments
 1 It'll Quench Ya!
-1 Lost in the Spirit World
+1 Lost in the Spirit World [TLE]
 1 Water Whip [TLE:227]
 1 Thriving Isle [TLE]
 7 Island

--- a/data/box/tla/Beginner Box - Waterbending.txt
+++ b/data/box/tla/Beginner Box - Waterbending.txt
@@ -1,7 +1,7 @@
 // NAME: Beginner Box - Waterbending
 // SOURCE: https://magic.wizards.com/en/news/announcements/avatar-the-last-airbender-beginner-box-contents
 // DATE: 2025-11-14
-1 Flying Dolphin-Fish
+1 Flying Dolphin-Fish [TLE]
 1 Otter-Penguin
 1 Katara, Bending Prodigy
 1 Sokka, Lateral Strategist


### PR DESCRIPTION
The Avatar Beginner Box themed decks mix cards from **Avatar: The Last Airbender Eternal (`TLE`)** with the Standard-legal main set (`TLA`). Sixteen `TLE` cards across 7 decks were unannotated — they resolved only because the indexer falls back to the card's sole printing, which is exactly the "figure it out between sets" case that's better made explicit (per the earlier Thriving-land fix).

Each is annotated `[TLE]` (every one has a single `TLE` printing, so no collector number is needed), matching the existing `Thriving …[TLE]` / `Feed the Swarm [TLE]` annotations:

| Deck | Cards annotated `[TLE]` |
|------|------|
| Allies | Kyoshi Warrior Guard, Mechanical Glider |
| Attacking | Purple Pentapus, Fire Nation Ambushers |
| Big Creatures | Frog-Squirrels, Match the Odds, Eel-Hounds, Hippo-Cows, Mechanical Glider |
| Counters | Gilacorn, Elephant-Rat |
| Firebending | Loyal Fire Sage, Roku's Mastery |
| Spells | Turtle-Seals, Lost in the Spirit World |
| Waterbending | Flying Dolphin-Fish |

Verified against the card DB: after the change, no card in these decks whose real `set_code` ≠ `tla` is left unannotated.

Also documents the convention in the README: **any card from a set different from the deck's own set must carry a `[SETCODE]` annotation** (`[SETCODE:number]` when a specific printing is needed).