### PR TITLE
Add Avatar: The Last Airbender Bundle Land Pack

### DIFF
--- a/data/bundle-land-pack/tla/Avatar- The Last Airbender Bundle Land Pack.txt
+++ b/data/bundle-land-pack/tla/Avatar- The Last Airbender Bundle Land Pack.txt
@@ -1,0 +1,29 @@
+// NAME: Avatar: The Last Airbender Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
+// DATE: 2025-11-21
+// Bundle land pack: 15 traditional foil + 15 non-foil basic lands. Each half is
+// 5 full-art Appa lands (#287-291, one per type) plus 10 standard-frame basics
+// (#282-286, two per type). The Avatar's journey full-art lands (#292-296) are
+// booster-only and not included in the bundle, so these are listed explicitly
+// rather than with the [TLA:*] round-robin (which would resolve to the
+// standard-frame basics and drop the Appa lands).
+2 Plains [TLA:282]
+1 Plains [TLA:287]
+2 Island [TLA:283]
+1 Island [TLA:288]
+2 Swamp [TLA:284]
+1 Swamp [TLA:289]
+2 Mountain [TLA:285]
+1 Mountain [TLA:290]
+2 Forest [TLA:286]
+1 Forest [TLA:291]
+2 Plains [TLA:282] [foil]
+1 Plains [TLA:287] [foil]
+2 Island [TLA:283] [foil]
+1 Island [TLA:288] [foil]
+2 Swamp [TLA:284] [foil]
+1 Swamp [TLA:289] [foil]
+2 Mountain [TLA:285] [foil]
+1 Mountain [TLA:290] [foil]
+2 Forest [TLA:286] [foil]
+1 Forest [TLA:291] [foil]


### PR DESCRIPTION
Adds the missing land-pack decklist for the Avatar: The Last Airbender Bundle.

30 cards = **15 traditional foil + 15 non-foil**, matching the [collecting article](https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender). Each half:
- 5 full-art **Appa** lands (#287-291), one per type
- 10 standard-frame basics (#282-286), two per type

The "Avatar's journey" full-art lands (#292-296) are booster-only and are **not** in the Bundle. Because the Bundle uses the full-art Appa lands, the collector numbers are listed explicitly — `[TLA:*]` round-robin would apply the resolver's `!fullart` filter and resolve every land to the standard-frame #282-286, dropping the Appa lands.

Validated: parses as a 30-card `bundle-land-pack`, all numbers resolve to real foil-capable printings.

Paired with a mtg-sealed-content PR that points the Bundle's land-pack component at this deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)