### PR TITLE
Add Tarkir: Dragonstorm Bundle Land Pack

### DIFF
--- a/data/bundle-land-pack/tdm/Tarkir- Dragonstorm Bundle Land Pack.txt
+++ b/data/bundle-land-pack/tdm/Tarkir- Dragonstorm Bundle Land Pack.txt
@@ -1,0 +1,37 @@
+// NAME: Tarkir: Dragonstorm Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-tarkir-dragonstorm
+// DATE: 2025-04-11
+// Bundle land pack: 15 traditional foil + 15 non-foil basic lands. Each half is
+// 5 full-art dragon's presence lands (#272-276, one per type) plus 10
+// default-frame basics (#277-286, both arts per type). The dragon's eye full-art
+// lands (#287-291) are Collector Booster-only and not included in the bundle.
+1 Plains [TDM:277]
+1 Plains [TDM:278]
+1 Plains [TDM:272]
+1 Island [TDM:279]
+1 Island [TDM:280]
+1 Island [TDM:273]
+1 Swamp [TDM:281]
+1 Swamp [TDM:282]
+1 Swamp [TDM:274]
+1 Mountain [TDM:283]
+1 Mountain [TDM:284]
+1 Mountain [TDM:275]
+1 Forest [TDM:285]
+1 Forest [TDM:286]
+1 Forest [TDM:276]
+1 Plains [TDM:277] [foil]
+1 Plains [TDM:278] [foil]
+1 Plains [TDM:272] [foil]
+1 Island [TDM:279] [foil]
+1 Island [TDM:280] [foil]
+1 Island [TDM:273] [foil]
+1 Swamp [TDM:281] [foil]
+1 Swamp [TDM:282] [foil]
+1 Swamp [TDM:274] [foil]
+1 Mountain [TDM:283] [foil]
+1 Mountain [TDM:284] [foil]
+1 Mountain [TDM:275] [foil]
+1 Forest [TDM:285] [foil]
+1 Forest [TDM:286] [foil]
+1 Forest [TDM:276] [foil]


### PR DESCRIPTION
Adds the missing 30-card bundle land pack (15 traditional foil + 15 non-foil) for Tarkir: Dragonstorm.

Per the [collecting article](https://magic.wizards.com/en/news/feature/collecting-tarkir-dragonstorm), each half is 5 full-art dragon's presence lands (#272-276) + 10 default-frame basics (#277-286, both arts, one each per type). The dragon's eye full-art series (#287-291) is Collector Booster-only and **not** in the bundle.

Explicit collector numbers (not `[SET:*]`) because the bundle uses full-art lands — the round-robin resolver's `!fullart` filter would drop them.

Validated: parses as a 30-card `bundle-land-pack` deck (15/15 foil split), all numbers resolve to real foil-capable printings.

Paired with a mtg-sealed-content PR linking the TDM Bundle's land-pack component to this deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)