### PR TITLE
dbtk: add Theros Beyond Death and Ravnica Allegiance toolkit decklists

### DIFF
--- a/data/dbtk/rna/Deck Builder's Toolkit.txt
+++ b/data/dbtk/rna/Deck Builder's Toolkit.txt
@@ -1,0 +1,117 @@
+// NAME: Deck Builder's Toolkit
+// SOURCE: https://mtg.wiki/wiki/Ravnica_Allegiance/Deck_Builder%27s_Toolkit
+// DATE: 2019-01-25
+1 Serra's Guardian [M19]
+1 Riddlemaster Sphinx [M19]
+1 Gravewaker [M19]
+1 Shivan Dragon [M19]
+1 Aggressive Mammoth [M19]
+1 Blade Instructor [GRN]
+1 Conclave Tribunal [GRN]
+1 Impassioned Orator
+1 Haazda Marshal [GRN]
+1 Healer's Hawk [GRN]
+1 Luminous Bonds [GRN]
+1 Ministrant of Obligation
+1 Spirit of the Spires
+1 Summary Judgment
+1 Sworn Companions [GRN]
+2 Take Heart [GRN]
+1 Arrester's Admonition
+1 Chemister's Insight [GRN]
+1 Faerie Duelist
+1 Leapfrog [GRN]
+1 Murmuring Mystic [GRN]
+1 Prying Eyes
+1 Pteramander
+1 Sinister Sabotage [GRN]
+1 Shimmer of Possibility
+1 Watcher in the Mist [GRN]
+2 Quench
+1 Barrier of Bones [GRN]
+1 Blade Juggler
+1 Carrion Imp
+1 Cry of the Carnarium
+1 Dead Revels
+1 Moodmark Painter [GRN]
+1 Orzhov Enforcer
+1 Price of Fame [GRN]
+1 Spinal Centipede [GRN]
+1 Whispering Snitch [GRN]
+2 Dead Weight [GRN]
+1 Burn Bright
+1 Clamor Shaman
+1 Electrostatic Field [GRN]
+1 Fire Urchin [GRN]
+1 Goblin Banneret [GRN]
+1 Lava Coil [GRN]
+1 Maximize Velocity [GRN]
+1 Rubblebelt Recluse
+1 Skewer the Critics
+3 Goblin Gathering
+1 Circuitous Route [GRN]
+1 District Guide [GRN]
+1 Golgari Raiders [GRN]
+1 Ironshell Beetle [GRN]
+1 Mammoth Spider
+1 Open the Gates
+1 Rampaging Rendhorn
+1 Siege Wurm [GRN]
+1 Territorial Boar
+1 Trollbred Guardian
+2 Prey Upon [GRN]
+1 Footlight Fiend
+1 Whisper Agent [GRN]
+1 Beacon Bolt [GRN]
+1 Boros Challenger [GRN]
+1 Conclave Cavalier [GRN]
+1 Crackling Drake [GRN]
+1 Dimir Spybug [GRN]
+1 Frilled Mystic
+1 Glowspore Shaman [GRN]
+1 Goblin Electromancer [GRN]
+1 Golgari Findbroker [GRN]
+1 Growth Spiral
+1 Hackrobat
+1 House Guildmage [GRN]
+1 Imperious Oligarch
+1 Lawmage's Binding
+1 Mortify
+1 Pitiless Pontiff
+1 Rakdos Firewheeler
+1 Rhizome Lurcher [GRN]
+1 Rosemane Centaur [GRN]
+1 Savage Smash
+1 Senate Guildmage
+1 Sharktocrab
+1 Skyknight Legionnaire [GRN]
+1 Sphinx of New Prahv
+1 Sunder Shaman
+1 Truefire Captain [GRN]
+1 Worldsoul Colossus [GRN]
+1 Zhur-Taa Goblin
+1 Azorius Locket
+1 Boros Locket [GRN]
+1 Dimir Locket [GRN]
+1 Golgari Locket [GRN]
+1 Gruul Locket
+1 Izzet Locket [GRN]
+1 Orzhov Locket
+1 Rakdos Locket
+1 Selesnya Locket [GRN]
+1 Simic Locket
+2 Azorius Guildgate
+2 Dimir Guildgate [GRN]
+2 Rakdos Guildgate
+2 Gruul Guildgate
+2 Selesnya Guildgate [GRN]
+2 Orzhov Guildgate
+2 Izzet Guildgate [GRN]
+2 Golgari Guildgate [GRN]
+2 Boros Guildgate [GRN]
+2 Simic Guildgate
+20 Plains [RNA:*]
+20 Island [RNA:*]
+20 Swamp [RNA:*]
+20 Mountain [RNA:*]
+20 Forest [RNA:*]

--- a/data/dbtk/thb/Deck Builder's Toolkit.txt
+++ b/data/dbtk/thb/Deck Builder's Toolkit.txt
@@ -1,0 +1,102 @@
+// NAME: Deck Builder's Toolkit
+// SOURCE: https://mtg.wiki/wiki/Theros_Beyond_Death/Deck_Builder%27s_Toolkit
+// DATE: 2020-01-24
+1 Victory's Envoy
+1 Serpent of Yawning Depths
+1 Demon of Loathing
+1 Terror of Mount Velus
+1 Treeshaker Chimera
+1 Ardenvale Paladin [ELD]
+1 Ardenvale Tactician [ELD]
+1 Banishing Light
+1 Daxos, Blessed by the Sun
+1 Daybreak Chimera
+1 Lonesome Unicorn [ELD]
+1 Mysterious Pathlighter [ELD]
+1 Reverent Hoplite
+1 Shepherd of the Flock [ELD]
+1 Silverflame Squire [ELD]
+1 Syr Alin, the Lion's Claw [ELD]
+1 Trapped in the Tower [ELD]
+2 Venerable Knight [ELD]
+1 Callaphe, Beloved of the Sea
+1 Charmed Sleep [ELD]
+2 Faerie Vandal [ELD]
+1 Glimpse of Freedom
+1 Hypnotic Sprite [ELD]
+1 Mantle of Tides [ELD]
+1 Opt [ELD]
+1 Sea God's Scorn
+1 So Tiny [ELD]
+1 Steelgaze Griffin [ELD]
+1 Thirst for Meaning
+2 Tome Raider [ELD]
+1 Unexplained Vision [ELD]
+1 Witching Well [ELD]
+2 Bake into a Pie [ELD]
+1 Barrow Witches [ELD]
+1 Blight-Breath Catoblepas
+1 Foulmire Knight [ELD]
+1 Funeral Rites
+1 Gray Merchant of Asphodel
+1 Locthwain Paladin [ELD]
+1 Memory Theft [ELD]
+1 Order of Midnight [ELD]
+1 Pharika's Spawn
+2 Reave Soul [ELD]
+1 Smitten Swordmaster [ELD]
+1 Tymaret, Chosen from Death
+1 Underworld Charger
+1 Anax, Hardened in the Forge
+2 Bloodhaze Wolverine [ELD]
+1 Burning-Yard Trainer [ELD]
+1 Claim the Firstborn [ELD]
+1 Fling [ELD]
+1 Merchant of the Vale [ELD]
+1 Ogre Errant [ELD]
+1 Raging Redcap [ELD]
+1 Rimrock Knight [ELD]
+1 Slaying Fire [ELD]
+2 Scorching Dragonfire [ELD]
+2 Thrill of Possibility
+1 Weaselback Redcap [ELD]
+2 Beanstalk Giant [ELD]
+2 Curious Pair [ELD]
+2 Flaxen Intruder [ELD]
+2 Garenbrig Carver [ELD]
+1 Nessian Wanderer
+2 Rosethorn Acolyte [ELD]
+1 Renata, Called to the Hunt
+1 Syr Faren, the Hengehammer [ELD]
+1 Tall as a Beanstalk [ELD]
+2 Tuinvale Treefolk [ELD]
+1 Acolyte of Affliction
+1 Devourer of Memory
+1 Grumgully, the Generous [ELD]
+2 Improbable Alliance [ELD]
+4 Inspiring Veteran [ELD]
+1 Maraleaf Pixie [ELD]
+1 Staggering Insight
+1 Steelclaw Lance [ELD]
+2 Wandermare [ELD]
+1 Wintermoor Commander [ELD]
+1 Bronze Sword
+1 Heraldic Banner [ELD]
+1 Jousting Dummy [ELD]
+2 Traveler's Amulet
+2 Bloodfell Caves [M20]
+2 Blossoming Sands [M20]
+2 Dismal Backwater [M20]
+2 Jungle Hollow [M20]
+2 Rugged Highlands [M20]
+2 Scoured Barrens [M20]
+2 Swiftwater Cliffs [M20]
+2 Thornwood Falls [M20]
+2 Tranquil Cove [M20]
+2 Unknown Shores
+2 Wind-Scarred Crag [M20]
+20 Plains [THB:*]
+20 Island [THB:*]
+20 Swamp [THB:*]
+20 Mountain [THB:*]
+20 Forest [THB:*]


### PR DESCRIPTION
Adds the two missing Deck Builder's Toolkit decklists (both from the all-fixed era — 125 fixed cards + 100 basics), sourced from mtg.wiki:

- `data/dbtk/thb/Deck Builder's Toolkit.txt` — [Theros Beyond Death toolkit](https://mtg.wiki/wiki/Theros_Beyond_Death/Deck_Builder%27s_Toolkit)
- `data/dbtk/rna/Deck Builder's Toolkit.txt` — [Ravnica Allegiance toolkit](https://mtg.wiki/wiki/Ravnica_Allegiance/Deck_Builder%27s_Toolkit)

Cards from a set other than the toolkit's own set carry an explicit `[SETCODE]` annotation (THB fixed cards come from THB + ELD + M20; RNA from RNA + GRN + M19), and basics use the round-robin `[SET:*]`. Every card name + set was resolved against the card database (no unresolved names); each list totals 225 cards.

These back the `Deck Builders Toolkit` product contents in `taw/mtg-sealed-content` (separate PR, which depends on this landing so the decks reach `decks_v2.json`).