### PR TITLE
Add Marvel's Spider-Man Web-Slingers Kit land packs

### DIFF
--- a/data/bundle-land-pack/spm/Marvel's Spider-Man Web-Slingers Kit Foil Land Pack.txt
+++ b/data/bundle-land-pack/spm/Marvel's Spider-Man Web-Slingers Kit Foil Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Marvel's Spider-Man Web-Slingers Kit Foil Land Pack
+// SOURCE: https://www.tcgplayer.com/product/663011/magic-marvels-spider-man-marvels-spider-man-web-slingers-kit
+// DATE: 2025-09-26
+// Costco-exclusive Web-Slingers Kit: 15 traditional foil default-frame basic
+// lands, 3 of each type. Bulk default basics, so uses the [SPM:*] round-robin
+// (which resolves to the default-frame printings, not the spiderweb full-arts).
+3 Plains [SPM:*] [foil]
+3 Island [SPM:*] [foil]
+3 Swamp [SPM:*] [foil]
+3 Mountain [SPM:*] [foil]
+3 Forest [SPM:*] [foil]

--- a/data/bundle-land-pack/spm/Marvel's Spider-Man Web-Slingers Kit Land Pack.txt
+++ b/data/bundle-land-pack/spm/Marvel's Spider-Man Web-Slingers Kit Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Marvel's Spider-Man Web-Slingers Kit Land Pack
+// SOURCE: https://www.tcgplayer.com/product/663011/magic-marvels-spider-man-marvels-spider-man-web-slingers-kit
+// DATE: 2025-09-26
+// Costco-exclusive Web-Slingers Kit: 30 regular (non-foil) default-frame basic
+// lands, 6 of each type. Bulk default basics, so uses the [SPM:*] round-robin
+// (which resolves to the default-frame printings, not the spiderweb full-arts).
+6 Plains [SPM:*]
+6 Island [SPM:*]
+6 Swamp [SPM:*]
+6 Mountain [SPM:*]
+6 Forest [SPM:*]

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -77,7 +77,8 @@ bundle-land-pack:
   format: null
   name: "Bundle Land Pack"
   sections:
-    Main Deck: [30, 32, 40]
+    # 15 = split foil/non-foil kit packs (e.g. SPM Web-Slingers Kit foil pack)
+    Main Deck: [15, 30, 32, 40]
 challenge:
   category: "deck"
   format: null


### PR DESCRIPTION
The Costco-exclusive [Web-Slingers Kit](https://www.tcgplayer.com/product/663011/magic-marvels-spider-man-marvels-spider-man-web-slingers-kit) contains **15 traditional foil + 30 regular basic lands** (plus 6 Play Boosters and a Miles Morales promo). Its land composition differs from the standard Bundle, so it gets its own two custom packs matching the two components:

- `Marvel's Spider-Man Web-Slingers Kit Land Pack` — 30 non-foil (6 of each type)
- `Marvel's Spider-Man Web-Slingers Kit Foil Land Pack` — 15 foil (3 of each type)

These are bulk default-frame basics, so they use the `[SPM:*]` round-robin, which resolves to the default-frame printings (#194-198) rather than the spiderweb full-arts (#189-193) — verified against the card index.

Adds `15` to the `bundle-land-pack` deck type's allowed `Main Deck` sizes so the split foil pack validates.

Paired with a mtg-sealed-content change linking the Web-Slingers Kit to these two decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)