### PR TITLE
dbtk: add Magic 2013 and Magic 2014 toolkit decklists (semi-random)

### DIFF
--- a/data/dbtk/m13/Angels.txt
+++ b/data/dbtk/m13/Angels.txt
@@ -1,0 +1,12 @@
+// NAME: Angels
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Defy Death [AVR]
+1 Emancipation Angel [AVR]
+1 Seraph of Dawn [AVR]
+2 Scroll of Avacyn [AVR]
+1 Seraph Sanctuary [AVR]
+1 Serra Angel
+1 Archangel [AVR]
+1 Angelic Wall [AVR]
+1 Bladed Bracers [AVR]

--- a/data/dbtk/m13/Blue Black Evasion.txt
+++ b/data/dbtk/m13/Blue Black Evasion.txt
@@ -1,0 +1,12 @@
+// NAME: Blue Black Evasion
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Bloodhunter Bat
+1 Curiosity [ISD]
+1 Faerie Invaders
+1 Gryff Vanguard [AVR]
+1 Harbor Bandit
+1 Invisible Stalker [ISD]
+2 Searchlight Geist [AVR]
+1 Talrand's Invocation
+1 Welkin Tern

--- a/data/dbtk/m13/Exalted.txt
+++ b/data/dbtk/m13/Exalted.txt
@@ -1,0 +1,12 @@
+// NAME: Exalted
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Knight of Glory
+1 Angelic Benediction
+2 Guardians of Akrasa
+1 Aven Squire
+1 Duty-Bound Dead
+1 Knight of Infamy
+1 Duskmantle Prowler
+1 Servant of Nefarox
+1 Cobbled Wings [ISD]

--- a/data/dbtk/m13/Fixed Content.txt
+++ b/data/dbtk/m13/Fixed Content.txt
@@ -1,0 +1,85 @@
+// NAME: Fixed Content
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Crusader of Odric
+1 Oblivion Ring
+1 Attended Knight
+1 Cathedral Sanctifier [AVR]
+1 Chapel Geist [ISD]
+1 Cloudshift [AVR]
+1 Elgaud Inquisitor [DKA]
+1 Glorious Charge
+1 Griffin Protector
+1 Niblis of the Mist [DKA]
+2 Pacifism
+1 Safe Passage
+1 Seraph of Dawn [AVR]
+1 Urgent Exorcism [ISD]
+1 Voice of the Provinces [AVR]
+1 Niblis of the Breath [DKA]
+1 Talrand's Invocation
+1 Mist Raven [AVR]
+1 Gryff Vanguard [AVR]
+1 Archaeomancer
+1 Stormbound Geist [DKA]
+1 Deranged Assistant [ISD]
+2 Welkin Tern
+1 Scroll Thief
+1 Thought Scour [DKA]
+1 Essence Scatter
+1 Negate
+1 Divination
+1 Curse of the Bloody Tome [ISD]
+1 Encrust
+1 Abattoir Ghoul [ISD]
+1 Vampire Nighthawk
+1 Bloodhunter Bat
+1 Dead Weight [ISD]
+1 Driver of the Dead [AVR]
+1 Duress
+1 Ghoulcaller's Chant [ISD]
+1 Liliana's Shade
+1 Markov Patrician [ISD]
+2 Murder
+1 Ravenous Rats
+1 Sign in Blood
+1 Tormented Soul
+1 Vampire Interloper [ISD]
+1 Victim of Night [ISD]
+1 Falkenrath Exterminator [AVR]
+1 Gang of Devils [AVR]
+1 Bladetusk Boar
+1 Brimstone Volley [ISD]
+1 Demolish [AVR]
+1 Fire Elemental
+1 Forge Devil [DKA]
+1 Heirs of Stromkirk [AVR]
+1 Krenko's Command
+2 Pillar of Flame [AVR]
+1 Pitchburn Devils [ISD]
+1 Rummaging Goblin
+1 Searing Spear
+1 Torch Fiend
+1 Traitorous Blood [ISD]
+1 Hollowhenge Scavenger [ISD]
+1 Roaring Primadox
+1 Ambush Viper [ISD]
+2 Arbor Elf
+1 Avacyn's Pilgrim [ISD]
+1 Borderland Ranger [AVR]
+1 Elvish Visionary
+1 Farseek
+1 Geist Trappers [AVR]
+1 Natural End [AVR]
+1 Pathbreaker Wurm [AVR]
+1 Prey Upon
+1 Ranger's Path
+1 Titanic Growth
+1 Wildwood Geist [AVR]
+1 Ghoulcaller's Bell [ISD]
+4 Evolving Wilds
+20 Plains [M13:*]
+20 Island [M13:*]
+20 Swamp [M13:*]
+20 Mountain [M13:*]
+20 Forest [M13:*]

--- a/data/dbtk/m13/Humans.txt
+++ b/data/dbtk/m13/Humans.txt
@@ -1,0 +1,12 @@
+// NAME: Humans
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Fiend Hunter [ISD]
+1 Crusader of Odric
+1 Gather the Townsfolk [DKA]
+2 Bonds of Faith [ISD]
+1 Avacyn's Pilgrim [ISD]
+1 Commander's Authority [AVR]
+1 Hamlet Captain [ISD]
+1 Heavy Mattock [DKA]
+1 Timberland Guide [AVR]

--- a/data/dbtk/m13/Library Depletion.txt
+++ b/data/dbtk/m13/Library Depletion.txt
@@ -1,0 +1,12 @@
+// NAME: Library Depletion
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Jace's Phantasm
+1 Stern Mentor [AVR]
+2 Mind Sculpt
+1 Curse of the Bloody Tome [ISD]
+1 Dreadwaters [AVR]
+1 Fog Bank
+1 Cellar Door [ISD]
+1 Vedalken Entrancer
+1 Dream Twist [ISD]

--- a/data/dbtk/m13/Midrange Green.txt
+++ b/data/dbtk/m13/Midrange Green.txt
@@ -1,0 +1,12 @@
+// NAME: Midrange Green
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Roaring Primadox
+1 Acidic Slime
+2 Borderland Ranger [AVR]
+1 Elvish Visionary
+1 Yeva's Forcemage
+1 Mwonvuli Beast Tracker
+1 Bond Beetle
+1 Timberland Guide [AVR]
+1 Briarpack Alpha [DKA]

--- a/data/dbtk/m13/Red Burn.txt
+++ b/data/dbtk/m13/Red Burn.txt
@@ -1,0 +1,12 @@
+// NAME: Red Burn
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Flames of the Firebrand
+1 Thunderous Wrath [AVR]
+1 Skirsdag Cultist [ISD]
+1 Curse of the Pierced Heart [ISD]
+2 Goblin Arsonist
+1 Searing Spear
+1 Volcanic Strength
+1 Geistflame [ISD]
+1 Chandra's Fury

--- a/data/dbtk/m13/Spirits.txt
+++ b/data/dbtk/m13/Spirits.txt
@@ -1,0 +1,12 @@
+// NAME: Spirits
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Gallows Warden [ISD]
+1 Drogskol Captain [DKA]
+1 Geist Snatch [AVR]
+2 Voiceless Spirit [ISD]
+1 Ghostly Possession [ISD]
+1 Battleground Geist [ISD]
+1 Midnight Haunting [ISD]
+1 Feeling of Dread [ISD]
+1 Spectral Prison [AVR]

--- a/data/dbtk/m13/Tokens.txt
+++ b/data/dbtk/m13/Tokens.txt
@@ -1,0 +1,12 @@
+// NAME: Tokens
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Intangible Virtue [ISD]
+1 Moan of the Unhallowed [ISD]
+1 Captain's Call
+1 Gather the Townsfolk [DKA]
+2 Vile Rebirth
+1 Lingering Souls [DKA]
+1 Goldnight Redeemer [AVR]
+1 Attended Knight
+1 Glorious Charge

--- a/data/dbtk/m13/Vampires.txt
+++ b/data/dbtk/m13/Vampires.txt
@@ -1,0 +1,12 @@
+// NAME: Vampires
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Vampire Nighthawk
+1 Rakish Heir [ISD]
+1 Vampiric Fury [ISD]
+1 Stromkirk Captain [DKA]
+2 Crossway Vampire [ISD]
+1 Vampire Interloper [ISD]
+1 Falkenrath Noble [ISD]
+1 Bloodcrazed Neonate [ISD]
+1 Victim of Night [ISD]

--- a/data/dbtk/m13/Zombies.txt
+++ b/data/dbtk/m13/Zombies.txt
@@ -1,0 +1,12 @@
+// NAME: Zombies
+// SOURCE: https://mtg.wiki/wiki/Magic_2013/Deck_Builder%27s_Toolkit
+// DATE: 2012-07-13
+1 Diregraf Captain [DKA]
+2 Armored Skaab [ISD]
+1 Black Cat [DKA]
+1 Screeching Skaab [DKA]
+1 Undead Executioner [AVR]
+1 Veilborn Ghoul
+1 Relentless Skaabs [DKA]
+1 Crypt Creeper [AVR]
+1 Skaab Goliath [ISD]

--- a/data/dbtk/m14/Black Control.txt
+++ b/data/dbtk/m14/Black Control.txt
@@ -1,0 +1,12 @@
+// NAME: Black Control
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Corrupt
+1 Doom Blade
+1 Diabolic Tutor
+1 Sengir Vampire
+2 Quag Sickness
+1 Mind Rot
+1 Child of Night
+1 Perilous Shadow [RTR]
+1 Deathgaze Cockatrice

--- a/data/dbtk/m14/Counterburn.txt
+++ b/data/dbtk/m14/Counterburn.txt
@@ -1,0 +1,12 @@
+// NAME: Counterburn
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Syncopate [RTR]
+1 Guttersnipe [RTR]
+1 Izzet Charm [RTR]
+1 Blast of Genius [DGM]
+2 Goblin Electromancer [RTR]
+1 Essence Backlash [RTR]
+1 Nivix Cyclops [DGM]
+1 Explosive Impact [RTR]
+1 Chandra's Outrage

--- a/data/dbtk/m14/Fixed Content.txt
+++ b/data/dbtk/m14/Fixed Content.txt
@@ -1,0 +1,85 @@
+// NAME: Fixed Content
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Angelic Wall
+1 Assault Griffin [GTC]
+1 Avenging Arrow [RTR]
+1 Blessing
+1 Capashen Knight
+1 Dawnstrike Paladin
+1 Fortify
+1 Griffin Sentinel
+1 Hive Stirrings
+1 Master of Diversion
+2 Pacifism
+1 Seller of Songbirds [RTR]
+1 Serra Angel
+1 Sunspire Griffin [RTR]
+1 Suntail Hawk
+2 Archaeomancer
+1 Cancel
+1 Disperse
+1 Divination
+1 Doorkeeper [RTR]
+1 Frost Breath
+1 Messenger Drake
+1 Opportunity
+1 Paralyzing Grasp [RTR]
+1 Seacoast Drake
+1 Skyline Predator [RTR]
+1 Stealer of Secrets [RTR]
+1 Tome Scour
+1 Voidwielder [RTR]
+1 Wind Drake [DGM]
+1 Accursed Spirit
+1 Child of Night
+1 Corpse Hauler
+1 Corrupt
+1 Deathgaze Cockatrice
+1 Doom Blade
+1 Drainpipe Vermin [RTR]
+1 Duress
+1 Festering Newt
+2 Liturgy of Blood
+1 Mind Rot
+1 Minotaur Abomination
+1 Nightwing Shade
+1 Stab Wound [RTR]
+1 Wring Flesh
+1 Act of Treason
+1 Annihilating Fire [RTR]
+1 Blur Sliver
+1 Chandra's Outrage
+1 Dragon Hatchling
+1 Flames of the Firebrand
+1 Goblin Shortcutter
+1 Guttersnipe [RTR]
+1 Pitchburn Devils
+1 Regathan Firecat
+1 Riot Piker [DGM]
+1 Seismic Stomp
+2 Shock
+1 Tenement Crasher [RTR]
+1 Viashino Racketeer [RTR]
+1 Aerial Predation [RTR]
+1 Axebane Stag [RTR]
+1 Briarpack Alpha
+1 Brindle Boar
+1 Centaur's Herald [RTR]
+1 Deadly Recluse
+2 Elvish Mystic
+1 Giant Growth
+1 Howl of the Night Pack
+1 Hunt the Weak
+1 Kraul Warrior [DGM]
+1 Predatory Sliver
+1 Rumbling Baloth
+1 Sporemound
+1 Trollhide
+1 Sliver Construct
+4 Transguild Promenade [RTR]
+20 Plains [M14:*]
+20 Island [M14:*]
+20 Swamp [M14:*]
+20 Mountain [M14:*]
+20 Forest [M14:*]

--- a/data/dbtk/m14/Library Depletion.txt
+++ b/data/dbtk/m14/Library Depletion.txt
@@ -1,0 +1,12 @@
+// NAME: Library Depletion
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Psychic Spiral [RTR]
+1 Codex Shredder [RTR]
+1 Millstone
+1 Coerced Confession [GTC]
+2 Tome Scour
+1 Doorkeeper [RTR]
+1 Psychic Strike [GTC]
+1 Paranoid Delusions [GTC]
+1 Pilfered Plans [DGM]

--- a/data/dbtk/m14/Life Gain.txt
+++ b/data/dbtk/m14/Life Gain.txt
@@ -1,0 +1,13 @@
+// NAME: Life Gain
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Voracious Wurm
+1 Angelic Accord
+1 Congregate
+1 Unflinching Courage [DGM]
+1 Centaur Healer [RTR]
+1 Soulmender
+1 Brindle Boar
+1 Dawnstrike Paladin
+1 Predator's Rapport [GTC]
+1 Divine Favor

--- a/data/dbtk/m14/Mana Ramp.txt
+++ b/data/dbtk/m14/Mana Ramp.txt
@@ -1,0 +1,13 @@
+// NAME: Mana Ramp
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Nimbus Swimmer [GTC]
+1 Seek the Horizon [RTR]
+1 Urban Evolution [GTC]
+1 Woodborn Behemoth
+1 Verdant Haven
+1 Gatecreeper Vine [RTR]
+1 Axebane Stag [RTR]
+1 Divination
+1 Axebane Guardian [RTR]
+1 Voidwielder [RTR]

--- a/data/dbtk/m14/Red-Green Aggression.txt
+++ b/data/dbtk/m14/Red-Green Aggression.txt
@@ -1,0 +1,13 @@
+// NAME: Red-Green Aggression
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Gruul War Chant [DGM]
+1 Zhur-Taa Swine [GTC]
+1 Advocate of the Beast
+1 Marauding Maulhorn
+1 Kraul Warrior [DGM]
+1 Mugging [GTC]
+1 Slaughterhorn [GTC]
+1 Ghor-Clan Rampager [GTC]
+1 Skarrg Guildmage [GTC]
+1 Kalonian Tusker

--- a/data/dbtk/m14/Red-White Swarm.txt
+++ b/data/dbtk/m14/Red-White Swarm.txt
@@ -1,0 +1,13 @@
+// NAME: Red-White Swarm
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Sunhome Guildmage [GTC]
+1 Truefire Paladin [GTC]
+1 Righteous Charge [GTC]
+1 Firefist Striker [GTC]
+1 Show of Valor
+1 Viashino Firstblade [DGM]
+1 Master of Diversion
+1 Riot Piker [DGM]
+1 Skyknight Legionnaire [GTC]
+1 Wojek Halberdiers [GTC]

--- a/data/dbtk/m14/Sacrifice.txt
+++ b/data/dbtk/m14/Sacrifice.txt
@@ -1,0 +1,13 @@
+// NAME: Sacrifice
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Gnawing Zombie
+1 Barrage of Expendables
+1 Tenacious Dead
+1 Goblin Rally [RTR]
+1 Act of Treason
+1 Blood Bairn
+1 Pitchburn Devils
+1 Festering Newt
+1 Drainpipe Vermin [RTR]
+1 Altar's Reap

--- a/data/dbtk/m14/Skies.txt
+++ b/data/dbtk/m14/Skies.txt
@@ -1,0 +1,13 @@
+// NAME: Skies
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Lyev Skyknight [RTR]
+1 Warden of Evos Isle
+1 Air Servant
+1 Jelenn Sphinx [DGM]
+1 Sunspire Griffin [RTR]
+1 Frost Breath
+1 Tower Drake [RTR]
+1 Assault Griffin [GTC]
+1 Concordia Pegasus [RTR]
+1 Hands of Binding [GTC]

--- a/data/dbtk/m14/Slivers.txt
+++ b/data/dbtk/m14/Slivers.txt
@@ -1,0 +1,11 @@
+// NAME: Slivers
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Steelform Sliver
+2 Battle Sliver
+1 Manaweft Sliver
+2 Predatory Sliver
+1 Sentinel Sliver
+1 Striking Sliver
+1 Blur Sliver
+1 Groundshaker Sliver

--- a/data/dbtk/m14/Tokens.txt
+++ b/data/dbtk/m14/Tokens.txt
@@ -1,0 +1,13 @@
+// NAME: Tokens
+// SOURCE: https://mtg.wiki/wiki/Magic_2014/Deck_Builder%27s_Toolkit
+// DATE: 2013-07-19
+1 Vitu-Ghazi Guildmage [RTR]
+1 Call of the Conclave [RTR]
+1 Slime Molding [RTR]
+1 Trostani's Summoner [DGM]
+1 Coursers' Accord [RTR]
+1 Centaur's Herald [RTR]
+1 Trostani's Judgment [RTR]
+1 Druid's Deliverance [RTR]
+1 Eyes in the Skies [RTR]
+1 Seller of Songbirds [RTR]


### PR DESCRIPTION
Adds the semi-random-era Deck Builder's Toolkit decklists for **Magic 2013** and **Magic 2014**, sourced from mtg.wiki:

- `data/dbtk/m13/` and `data/dbtk/m14/` — each a **Fixed Content** deck (85 fixed cards + 100 basics) plus the **11 themed "strategy" groups** of 10 cards (the physical toolkit shipped a random 4 of the 11, modeled downstream with `variable_mode`).

Cards from a set other than the toolkit's own set carry an explicit `[SETCODE]` annotation (M13 fixed/semi cards come from M13 + ISD + DKA + AVR; M14 from M14 + RTR + GTC + DGM). Every card name and set was resolved against the card database (no unresolved names); Fixed Content totals 185, each group totals 10.

Back the Deck Builders Toolkit contents in `mtgjson/mtg-sealed-content` (separate PR).