### PR TITLE
dbtk: add Magic Origins and Shadows over Innistrad toolkit decklists

### DIFF
--- a/data/dbtk/ori/Black Green Toughness.txt
+++ b/data/dbtk/ori/Black Green Toughness.txt
@@ -1,0 +1,13 @@
+// NAME: Black Green Toughness
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Kheru Bloodsucker [KTK]
+1 Sultai Flayer [KTK]
+1 Kin-Tree Invocation [KTK]
+1 Sight of the Scalelords [DTK]
+1 Hitchclaw Recluse
+1 Rotting Mastodon [KTK]
+1 Reach of Shadows [FRF]
+1 Grim Contest [FRF]
+1 Coat with Venom [DTK]
+1 Colossodon Yearling [DTK]

--- a/data/dbtk/ori/Blue Black Exploit.txt
+++ b/data/dbtk/ori/Blue Black Exploit.txt
@@ -1,0 +1,13 @@
+// NAME: Blue Black Exploit
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Merciless Executioner [FRF]
+1 Silumgar Sorcerer [DTK]
+1 Youthful Scholar [DTK]
+1 Rakshasa Gravecaller [DTK]
+1 Macabre Waltz
+1 Deadbridge Shaman
+1 Whisk Away [FRF]
+1 Gurmag Drowner [DTK]
+1 Sidisi's Faithful [DTK]
+1 Dutiful Attendant [DTK]

--- a/data/dbtk/ori/Blue Green Secret Plans Morph.txt
+++ b/data/dbtk/ori/Blue Green Secret Plans Morph.txt
@@ -1,0 +1,13 @@
+// NAME: Blue Green Secret Plans Morph
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Pine Walker [KTK]
+1 Icefeather Aven [KTK]
+1 Secret Plans [KTK]
+1 Qarsi Deceiver [DTK]
+1 Claustrophobia
+1 Write into Being [FRF]
+1 Ambush Krotiq [FRF]
+1 Ethereal Ambush [FRF]
+1 Ojutai Interceptor [DTK]
+1 Guardian Shield-Bearer [DTK]

--- a/data/dbtk/ori/Blue Red Artifacts.txt
+++ b/data/dbtk/ori/Blue Red Artifacts.txt
@@ -1,0 +1,13 @@
+// NAME: Blue Red Artifacts
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Thopter Engineer
+1 Chief of the Foundry
+1 Reclusive Artificer
+1 Briber's Purse [KTK]
+1 Guardian Automaton
+1 Aspiring Aeronaut
+1 Ghirapur Gearcrafter
+1 Singing Bell Strike [KTK]
+1 Bathe in Dragonfire [FRF]
+1 Spidersilk Net [DTK]

--- a/data/dbtk/ori/Blue Red Counterburn.txt
+++ b/data/dbtk/ori/Blue Red Counterburn.txt
@@ -1,0 +1,13 @@
+// NAME: Blue Red Counterburn
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Ravaging Blaze
+1 Goblinslide [KTK]
+1 Master the Way [KTK]
+1 Skywise Teachings [DTK]
+1 Fiery Impulse
+1 Send to Sleep
+1 Cancel [KTK]
+1 Cunning Strike [FRF]
+1 Elusive Spellfist [DTK]
+1 Twin Bolt [DTK]

--- a/data/dbtk/ori/Fixed Content.txt
+++ b/data/dbtk/ori/Fixed Content.txt
@@ -1,0 +1,80 @@
+// NAME: Fixed Content
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Aegis Angel
+1 Mahamoti Djinn
+1 Nightmare
+1 Shivan Dragon
+1 Terra Stomper
+1 Serra Angel
+1 Silkwrap [DTK]
+1 Divine Verdict
+1 Eagle of the Watch
+1 Alabaster Kirin [KTK]
+1 Celestial Flare
+1 Erase [KTK]
+1 Feat of Resistance [KTK]
+1 Aven Skirmisher [FRF]
+1 Artful Maneuver [DTK]
+1 Pacifism [DTK]
+1 Frost Walker [FRF]
+1 Into the Void
+1 Weave Fate
+1 Disdainful Stroke [KTK]
+1 Claustrophobia
+1 Singing Bell Strike [KTK]
+1 Faerie Miscreant
+1 Aven Surveyor [FRF]
+1 Anticipate [DTK]
+1 Elusive Spellfist [DTK]
+1 Negate
+1 Sengir Vampire
+1 Ultimate Price [DTK]
+1 Mind Rot
+1 Flesh to Dust
+1 Reave Soul
+1 Deadbridge Shaman
+1 Debilitating Injury [KTK]
+1 Hooded Assassin [FRF]
+1 Typhoid Rats [FRF]
+1 Flatten [DTK]
+1 Hand of Silumgar [DTK]
+1 Arc Lightning [KTK]
+1 Wild Slash [FRF]
+1 Fiery Hellhound
+1 Act of Treason
+1 Dragon Fodder
+1 Prickleboar
+1 Trumpet Blast [KTK]
+1 Bathe in Dragonfire [FRF]
+1 Mardu Scout [FRF]
+1 Tormenting Voice [KTK]
+1 Twin Bolt [DTK]
+1 Prized Unicorn
+1 Heir of the Wilds [KTK]
+1 Elvish Visionary
+1 Nissa's Pilgrimage
+1 Titanic Growth
+1 Plummet
+1 Dragonscale Boon [KTK]
+1 Naturalize [KTK]
+1 Ainok Guide [FRF]
+1 Whisperer of the Wilds [FRF]
+1 Colossodon Yearling [DTK]
+1 Spidersilk Net [DTK]
+4 Evolving Wilds
+2 Rugged Highlands [KTK]
+2 Wind-Scarred Crag [KTK]
+2 Thornwood Falls [KTK]
+2 Scoured Barrens [KTK]
+2 Bloodfell Caves [KTK]
+2 Blossoming Sands [KTK]
+2 Dismal Backwater [KTK]
+2 Jungle Hollow [KTK]
+2 Swiftwater Cliffs [KTK]
+2 Tranquil Cove [KTK]
+20 Plains [ORI:*]
+20 Island [ORI:*]
+20 Swamp [ORI:*]
+20 Mountain [ORI:*]
+20 Forest [ORI:*]

--- a/data/dbtk/ori/Green Red Beatdown.txt
+++ b/data/dbtk/ori/Green Red Beatdown.txt
@@ -1,0 +1,13 @@
+// NAME: Green Red Beatdown
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Zendikar Incarnate
+1 Dragon Grip [KTK]
+1 Atarka Pummeler [DTK]
+1 Circle of Elders [DTK]
+1 Titanic Growth
+1 Barrage of Boulders [KTK]
+1 Savage Punch [KTK]
+1 Frontier Mastodon [FRF]
+1 Whisperer of the Wilds [FRF]
+1 Sabertooth Outrider [DTK]

--- a/data/dbtk/ori/Red Burn.txt
+++ b/data/dbtk/ori/Red Burn.txt
@@ -1,0 +1,13 @@
+// NAME: Red Burn
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Ravaging Blaze
+1 Arc Lightning [KTK]
+1 Monastery Swiftspear [KTK]
+1 Wild Slash [FRF]
+1 Lightning Javelin
+1 Mage-Ring Bully
+1 Valley Dasher [KTK]
+1 Mardu Scout [FRF]
+1 Sarkhan's Rage [DTK]
+1 Twin Bolt [DTK]

--- a/data/dbtk/ori/White Black Auras.txt
+++ b/data/dbtk/ori/White Black Auras.txt
@@ -1,0 +1,13 @@
+// NAME: White Black Auras
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Totem-Guide Hartebeest
+1 Blightcaster
+1 Blood-Cursed Knight
+1 Sage's Reverie [FRF]
+1 Infernal Scarring
+1 Fetid Imp
+1 Auramancer
+1 Debilitating Injury [KTK]
+1 Ancestral Vengeance [FRF]
+1 Pacifism [DTK]

--- a/data/dbtk/ori/White Black Warriors.txt
+++ b/data/dbtk/ori/White Black Warriors.txt
@@ -1,0 +1,13 @@
+// NAME: White Black Warriors
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Chief of the Edge [KTK]
+1 Chief of the Scale [KTK]
+1 Mardu Woe-Reaper [FRF]
+1 Blood-Chin Rager [DTK]
+1 Rush of Battle [KTK]
+1 Aven Skirmisher [FRF]
+1 Harsh Sustenance [FRF]
+1 Herald of Dromoka [DTK]
+1 Hand of Silumgar [DTK]
+1 Flatten [DTK]

--- a/data/dbtk/ori/White Blue Prowess.txt
+++ b/data/dbtk/ori/White Blue Prowess.txt
@@ -1,0 +1,13 @@
+// NAME: White Blue Prowess
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Suspension Field [KTK]
+1 Mistfire Adept [FRF]
+1 Strongarm Monk [DTK]
+1 Void Squall [DTK]
+1 Ringwarden Owl
+1 Jeskai Student [KTK]
+1 Weave Fate
+1 Artful Maneuver [DTK]
+1 Student of Ojutai [DTK]
+1 Ojutai's Breath [DTK]

--- a/data/dbtk/ori/White Green Aggro.txt
+++ b/data/dbtk/ori/White Green Aggro.txt
@@ -1,0 +1,13 @@
+// NAME: White Green Aggro
+// SOURCE: https://mtg.wiki/wiki/Magic_Origins/Deck_Builder%27s_Toolkit
+// DATE: 2015-07-17
+1 Valeron Wardens
+1 Citadel Castellan
+1 Abzan Falconer [KTK]
+1 Incremental Growth [KTK]
+1 Enshrouding Mist
+1 Topan Freeblade
+1 Pharika's Disciple
+1 Rhox Maulers
+1 Dragonscale Boon [KTK]
+1 Sandblast [FRF]

--- a/data/dbtk/soi/Black and Green Graveyard.txt
+++ b/data/dbtk/soi/Black and Green Graveyard.txt
@@ -1,0 +1,13 @@
+// NAME: Black and Green Graveyard
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Carrier Thrall [BFZ]
+1 Vampiric Rites [BFZ]
+1 Rot Shambler [BFZ]
+1 Seed Guardian [OGW]
+1 Bone Splinters [BFZ]
+1 Voracious Null [BFZ]
+1 Plummet [BFZ]
+1 Pulse of Murasa [OGW]
+1 Vines of the Recluse [OGW]
+1 Ghoulcaller's Accomplice

--- a/data/dbtk/soi/Black and Red Attrition.txt
+++ b/data/dbtk/soi/Black and Red Attrition.txt
@@ -1,0 +1,13 @@
+// NAME: Black and Red Attrition
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Rolling Thunder [BFZ]
+1 Blighted Fen [BFZ]
+1 Grasp of Darkness [OGW]
+1 Ghoulsteed
+1 Demon's Grasp [BFZ]
+1 Goblin War Paint [BFZ]
+1 Tar Snare [OGW]
+1 Cinder Hellion [OGW]
+1 Ember-Eye Wolf
+1 Rancid Rats

--- a/data/dbtk/soi/Blue and Black Control.txt
+++ b/data/dbtk/soi/Blue and Black Control.txt
@@ -1,0 +1,13 @@
+// NAME: Blue and Black Control
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Windrider Patrol [BFZ]
+1 Blighted Cataract [BFZ]
+1 Pale Rider of Trostad
+1 Sinister Concoction
+1 Coralhelm Guide [BFZ]
+1 Negate [OGW]
+1 Corpse Churn [OGW]
+1 Furtive Homunculus
+1 Dead Weight
+1 Sanitarium Skeleton

--- a/data/dbtk/soi/Blue and Green Creature control.txt
+++ b/data/dbtk/soi/Blue and Green Creature control.txt
@@ -1,0 +1,13 @@
+// NAME: Blue and Green Creature control
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Roiling Waters [OGW]
+1 Reckless Scholar
+1 Gloomwidow
+1 Pack Guardian
+1 Giant Mantis [BFZ]
+1 Lifespring Druid [BFZ]
+1 Ancient Crab [OGW]
+1 Sweep Away [OGW]
+1 Tajuru Pathwarden [OGW]
+1 Ghostly Wings

--- a/data/dbtk/soi/Blue and Red Instants and Sorceries.txt
+++ b/data/dbtk/soi/Blue and Red Instants and Sorceries.txt
@@ -1,0 +1,13 @@
+// NAME: Blue and Red Instants and Sorceries
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Reckless Bushwhacker [OGW]
+1 Pore Over the Pages
+1 Rise from the Tides
+1 Geistblast
+1 Anticipate [BFZ]
+1 Cloud Manta [BFZ]
+1 Slip Through Space [OGW]
+1 Expedite [OGW]
+1 Pyre Hound
+1 Sanguinary Mage

--- a/data/dbtk/soi/Fixed Content.txt
+++ b/data/dbtk/soi/Fixed Content.txt
@@ -1,0 +1,80 @@
+// NAME: Fixed Content
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Aegis Angel [W16]
+1 Sphinx of Magosi [W16]
+1 Nightmare [W16]
+1 Shivan Dragon [W16]
+1 Soul of the Harvest [W16]
+1 Serra Angel [W16]
+1 Stern Constable
+1 Inspired Charge [BFZ]
+1 Unruly Mob
+1 Stasis Snare [BFZ]
+1 Cliffside Lookout [BFZ]
+1 Marked by Honor [W16]
+1 Angelic Gift [BFZ]
+1 Kitesail Scout [BFZ]
+1 Ghostly Sentinel [BFZ]
+1 Air Servant [W16]
+1 Pore Over the Pages
+1 Dispel [BFZ]
+1 Disperse [W16]
+1 Anticipate [BFZ]
+1 Negate [OGW]
+1 Sweep Away [OGW]
+1 Pieces of the Puzzle
+1 Niblis of Dusk
+1 Stitched Mangler
+1 Sengir Vampire [W16]
+1 Mind Rot [W16]
+1 Walking Corpse [W16]
+1 Bone Splinters [BFZ]
+1 Crow of Dark Tidings
+1 Macabre Waltz
+1 Vampire Envoy [OGW]
+1 Shamble Back
+1 Zulaport Cutthroat [BFZ]
+1 Dead Weight
+1 Cone of Flame [W16]
+1 Lightning Axe
+1 Brute Strength [OGW]
+1 Cinder Hellion [OGW]
+1 Expedite [OGW]
+1 Magmatic Chasm
+1 Ember-Eye Wolf
+1 Voldaren Duelist
+1 Sanguinary Mage
+1 Borderland Marauder [W16]
+1 Pack Guardian
+1 Incremental Growth [W16]
+1 Oran-Rief Invoker [BFZ]
+1 Plummet [BFZ]
+1 Quilled Wolf
+1 Lifespring Druid [BFZ]
+1 Oakenform [W16]
+1 Tajuru Pathwarden [OGW]
+1 Rabid Bite
+1 Loam Larva [OGW]
+1 Bone Saw [OGW]
+1 Hedron Crawler [OGW]
+1 Explosive Apparatus
+1 Chitinous Cloak [OGW]
+1 Evolving Wilds [BFZ]
+1 Crumbling Vestige [OGW]
+2 Cinder Barrens [OGW]
+2 Submerged Boneyard [OGW]
+2 Highland Lake
+2 Forsaken Sanctuary
+2 Foul Orchard
+2 Stone Quarry
+2 Meandering River [OGW]
+2 Woodland Stream
+2 Timber Gorge [OGW]
+2 Tranquil Expanse [OGW]
+4 Unknown Shores [OGW]
+20 Plains [SOI:*]
+20 Island [SOI:*]
+20 Swamp [SOI:*]
+20 Mountain [SOI:*]
+20 Forest [SOI:*]

--- a/data/dbtk/soi/Red and Colorless RampLandfall.txt
+++ b/data/dbtk/soi/Red and Colorless RampLandfall.txt
@@ -1,0 +1,13 @@
+// NAME: Red and Colorless RampLandfall
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Bane of Bala Ged [BFZ]
+1 Hedron Archive [BFZ]
+1 Devour in Flames [OGW]
+1 Embodiment of Fury [OGW]
+1 Scour from Existence [BFZ]
+1 Makindi Sliderunner [BFZ]
+1 Valakut Predator [BFZ]
+1 Sparkmage's Gambit [OGW]
+1 Hedron Crawler [OGW]
+1 Seer's Lantern [OGW]

--- a/data/dbtk/soi/Red and Green Landfall.txt
+++ b/data/dbtk/soi/Red and Green Landfall.txt
@@ -1,0 +1,13 @@
+// NAME: Red and Green Landfall
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Retreat to Valakut [BFZ]
+1 Blighted Gorge [BFZ]
+1 Relentless Hunter [OGW]
+1 Lightning Axe
+1 Lavastep Raider [BFZ]
+1 Sure Strike [BFZ]
+1 Snapping Gnarlid [BFZ]
+1 Territorial Baloth [BFZ]
+1 Brute Strength [OGW]
+1 Loam Larva [OGW]

--- a/data/dbtk/soi/White and Black Life gain.txt
+++ b/data/dbtk/soi/White and Black Life gain.txt
@@ -1,0 +1,13 @@
+// NAME: White and Black Life gain
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Serene Steward [BFZ]
+1 Malakir Familiar [BFZ]
+1 Zulaport Cutthroat [BFZ]
+1 Allied Reinforcements [OGW]
+1 Inspired Charge [BFZ]
+1 Stone Haven Medic [BFZ]
+1 Nirkana Assassin [BFZ]
+1 Vampire Envoy [OGW]
+1 Dauntless Cathar
+1 Grotesque Mutation

--- a/data/dbtk/soi/White and Blue Fliers Control.txt
+++ b/data/dbtk/soi/White and Blue Fliers Control.txt
@@ -1,0 +1,13 @@
+// NAME: White and Blue Fliers Control
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Angel of Renewal [BFZ]
+1 Dampening Pulse [BFZ]
+1 Blighted Steppe [BFZ]
+1 Reflector Mage [OGW]
+1 Felidar Cub [BFZ]
+1 Gideon's Reproach [BFZ]
+1 Kor Sky Climber [OGW]
+1 Dispel [BFZ]
+1 Stormrider Spirit
+1 Tightening Coils [BFZ]

--- a/data/dbtk/soi/White and Colorless Equipment.txt
+++ b/data/dbtk/soi/White and Colorless Equipment.txt
@@ -1,0 +1,13 @@
+// NAME: White and Colorless Equipment
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Immolating Glare [OGW]
+1 Chitinous Cloak [OGW]
+1 Strider Harness [OGW]
+1 Open the Armory
+1 Kozilek's Channeler [BFZ]
+1 Kor Scythemaster [OGW]
+1 Bone Saw [OGW]
+1 Militant Inquisitor
+1 Stern Constable
+1 True-Faith Censer

--- a/data/dbtk/soi/White and Green counters.txt
+++ b/data/dbtk/soi/White and Green counters.txt
@@ -1,0 +1,13 @@
+// NAME: White and Green counters
+// SOURCE: https://mtg.wiki/wiki/Shadows_over_Innistrad/Deck_Builder%27s_Toolkit
+// DATE: 2016-04-08
+1 Expedition Envoy [BFZ]
+1 Stasis Snare [BFZ]
+1 Retreat to Kazandu [BFZ]
+1 Blighted Woodland [BFZ]
+1 Cliffside Lookout [BFZ]
+1 Tandem Tactics [BFZ]
+1 Oran-Rief Invoker [BFZ]
+1 Expedition Raptor [OGW]
+1 Natural State [OGW]
+1 Netcaster Spider [OGW]


### PR DESCRIPTION
Adds the last two semi-random-era Deck Builder's Toolkit decklists — **Magic Origins** and **Shadows over Innistrad** — sourced from mtg.wiki:

- `data/dbtk/ori/` and `data/dbtk/soi/` — each a **Fixed Content** deck (85 fixed + 100 basics) plus the **11 themed "strategy" groups** of 10 cards (the box shipped a random 4 of 11, modeled downstream with `variable_mode`).

Cross-set cards carry an explicit `[SETCODE]` annotation (ORI fixed/semi cards come from ORI + KTK + FRF + DTK; SOI from SOI + OGW + BFZ + W16). Every card name and set resolved against the card database (no unresolved names); Fixed Content totals 185, each group totals 10.

Completes the Deck Builder's Toolkit decklist set (with #274 and #277); backs the Deck Builders Toolkit contents in `mtgjson/mtg-sealed-content` (separate PR).