### PR TITLE
Add DMU, SNC, BRO bundle land packs

### DIFF
--- a/data/bundle-land-pack/bro/The Brothers' War Bundle Land Pack.txt
+++ b/data/bundle-land-pack/bro/The Brothers' War Bundle Land Pack.txt
@@ -1,0 +1,17 @@
+// NAME: The Brothers' War Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/the-brothers-war
+// DATE: 2022-11-18
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil, 4 of each
+// type per finish. Default-frame basics (the full-art mech lands are
+// booster-only), so [BRO:*] round-robins the default printings. The Bundle and
+// Gift Bundle contain the same lands.
+4 Plains [BRO:*]
+4 Island [BRO:*]
+4 Swamp [BRO:*]
+4 Mountain [BRO:*]
+4 Forest [BRO:*]
+4 Plains [BRO:*] [foil]
+4 Island [BRO:*] [foil]
+4 Swamp [BRO:*] [foil]
+4 Mountain [BRO:*] [foil]
+4 Forest [BRO:*] [foil]

--- a/data/bundle-land-pack/dmu/Dominaria United Bundle Land Pack.txt
+++ b/data/bundle-land-pack/dmu/Dominaria United Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Dominaria United Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/dominaria-united-product-overview-2022-08-18
+// DATE: 2022-09-09
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil, 4 of each
+// type per finish. Default-frame basics (the stained-glass full-art lands are
+// booster-only), so [DMU:*] round-robins the default printings.
+4 Plains [DMU:*]
+4 Island [DMU:*]
+4 Swamp [DMU:*]
+4 Mountain [DMU:*]
+4 Forest [DMU:*]
+4 Plains [DMU:*] [foil]
+4 Island [DMU:*] [foil]
+4 Swamp [DMU:*] [foil]
+4 Mountain [DMU:*] [foil]
+4 Forest [DMU:*] [foil]

--- a/data/bundle-land-pack/snc/Streets of New Capenna Bundle Land Pack.txt
+++ b/data/bundle-land-pack/snc/Streets of New Capenna Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Streets of New Capenna Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/streets-of-new-capenna-product-overview-2022-04-07
+// DATE: 2022-04-29
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil, 4 of each
+// type per finish. Default-frame basics (the metropolis full-art lands are
+// booster-only), so [SNC:*] round-robins the default printings.
+4 Plains [SNC:*]
+4 Island [SNC:*]
+4 Swamp [SNC:*]
+4 Mountain [SNC:*]
+4 Forest [SNC:*]
+4 Plains [SNC:*] [foil]
+4 Island [SNC:*] [foil]
+4 Swamp [SNC:*] [foil]
+4 Mountain [SNC:*] [foil]
+4 Forest [SNC:*] [foil]


### PR DESCRIPTION
Adds the missing 2022 bundle land packs for Dominaria United, Streets of New Capenna, and The Brothers' War.

Each is **40 basic lands (20 traditional foil + 20 non-foil, 4 of each type per finish)**, per the product overviews. All are default-frame basics — the sets' full-art lands (DMU stained-glass #277-281, SNC metropolis #272-281, BRO mech #278-287) are booster-only — so each pack uses the `[SET:*]` round-robin, verified to resolve to the default-frame printings only.

The Brothers' War Bundle and Gift Bundle contain identical lands, so both reference the single `The Brothers' War Bundle Land Pack`.

Validated: all three parse as 40-card `bundle-land-pack` decks (20/20 foil split); round-robin targets confirmed against the card index.

Paired with a mtg-sealed-content PR linking each Bundle's land-pack component to these decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)