### PR TITLE
Add Marvel Super Heroes Draft Night Land Pack

### DIFF
--- a/data/bundle-land-pack/msh/Marvel Super Heroes Draft Night Land Pack.txt
+++ b/data/bundle-land-pack/msh/Marvel Super Heroes Draft Night Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Marvel Super Heroes Draft Night Land Pack
+// SOURCE: https://magic.wizards.com/en/news/feature/collecting-marvel-super-heroes
+// DATE: 2025-09-26
+// Draft Night ships 90 non-foil basic lands for deck building, split evenly
+// across the five types. Uses [MSH:*] so each type resolves to the set's
+// default non-foil basic printing rather than the foil-only variants.
+18 Plains [MSH:*]
+18 Island [MSH:*]
+18 Swamp [MSH:*]
+18 Mountain [MSH:*]
+18 Forest [MSH:*]


### PR DESCRIPTION
Adds a `Marvel Super Heroes Draft Night Land Pack` decklist for the Draft Night product's **90 non-foil basic lands** (18 of each type).

This is distinct from the existing `Marvel Super Heroes Bundle Land Pack` (30 cards: 15 traditional foil + 15 non-foil full-art). Draft Night's lands are plain deck-building basics, so this pack uses `[MSH:*]` to resolve each type to the set's default non-foil basic printing (avoiding the foil-only #433–442 variants).

Referenced by the Marvel Super Heroes Draft Night contents in `mtgjson/mtg-sealed-content` (#499).