### PR TITLE
Add bundle land packs (ELD, IKO, M21, MH2)

### DIFF
--- a/data/bundle-land-pack/eld/Throne of Eldraine Bundle Land Pack.txt
+++ b/data/bundle-land-pack/eld/Throne of Eldraine Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Throne of Eldraine Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/throne-of-eldraine
+// DATE: 2019-10-04
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish (per the sealed-content contents). Default-frame
+// basics, so [ELD:*] round-robins the set's printings.
+4 Plains [ELD:*]
+4 Island [ELD:*]
+4 Swamp [ELD:*]
+4 Mountain [ELD:*]
+4 Forest [ELD:*]
+4 Plains [ELD:*] [foil]
+4 Island [ELD:*] [foil]
+4 Swamp [ELD:*] [foil]
+4 Mountain [ELD:*] [foil]
+4 Forest [ELD:*] [foil]

--- a/data/bundle-land-pack/iko/Ikoria- Lair of Behemoths Bundle Land Pack.txt
+++ b/data/bundle-land-pack/iko/Ikoria- Lair of Behemoths Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Ikoria: Lair of Behemoths Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/ikoria-lair-of-behemoths
+// DATE: 2020-04-24
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish (per the sealed-content contents). Default-frame
+// basics, so [IKO:*] round-robins the set's printings.
+4 Plains [IKO:*]
+4 Island [IKO:*]
+4 Swamp [IKO:*]
+4 Mountain [IKO:*]
+4 Forest [IKO:*]
+4 Plains [IKO:*] [foil]
+4 Island [IKO:*] [foil]
+4 Swamp [IKO:*] [foil]
+4 Mountain [IKO:*] [foil]
+4 Forest [IKO:*] [foil]

--- a/data/bundle-land-pack/m21/Core Set 2021 Bundle Land Pack.txt
+++ b/data/bundle-land-pack/m21/Core Set 2021 Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Core Set 2021 Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/core-set-2021
+// DATE: 2020-07-03
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish (per the sealed-content contents). Default-frame
+// basics, so [M21:*] round-robins the set's printings.
+4 Plains [M21:*]
+4 Island [M21:*]
+4 Swamp [M21:*]
+4 Mountain [M21:*]
+4 Forest [M21:*]
+4 Plains [M21:*] [foil]
+4 Island [M21:*] [foil]
+4 Swamp [M21:*] [foil]
+4 Mountain [M21:*] [foil]
+4 Forest [M21:*] [foil]

--- a/data/bundle-land-pack/mh2/Modern Horizons 2 Bundle Land Pack.txt
+++ b/data/bundle-land-pack/mh2/Modern Horizons 2 Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Modern Horizons 2 Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/modern-horizons-2
+// DATE: 2021-06-18
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish (per the sealed-content contents). Default-frame
+// basics, so [MH2:*] round-robins the set's printings.
+4 Plains [MH2:*]
+4 Island [MH2:*]
+4 Swamp [MH2:*]
+4 Mountain [MH2:*]
+4 Forest [MH2:*]
+4 Plains [MH2:*] [foil]
+4 Island [MH2:*] [foil]
+4 Swamp [MH2:*] [foil]
+4 Mountain [MH2:*] [foil]
+4 Forest [MH2:*] [foil]


### PR DESCRIPTION
Adds bundle land packs for Throne of Eldraine, Ikoria, Core Set 2021, and Modern Horizons 2.

Each is **40 basic lands (20 traditional foil + 20 non-foil, 4 of each type per finish)** — the counts are taken directly from mtg-sealed-content, which lists "20 foil basic lands" + "20 nonfoil basic lands" (or the equivalent Non-Foil/Foil land bundle lines) for each. All four are default-frame basics (no full-art), so each uses the `[SET:*]` round-robin, verified against the card index.

40 is already a valid `bundle-land-pack` size, so no deck-type change.

Paired with a mtg-sealed-content PR linking each Bundle's land component to these decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)