### PR TITLE
Add bundle land packs (NEO, LTR, MOM, ONE, WOE, SOS)

### DIFF
--- a/data/bundle-land-pack/ltr/The Lord of the Rings- Tales of Middle-earth Bundle Land Pack.txt
+++ b/data/bundle-land-pack/ltr/The Lord of the Rings- Tales of Middle-earth Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: The Lord of the Rings: Tales of Middle-earth Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/the-lord-of-the-rings-tales-of-middle-earth
+// DATE: 2023-06-23
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish. The bundle uses the regular default-frame basics
+// (the set's full-art lands are booster-only), so [LTR:*] round-robins those.
+4 Plains [LTR:*]
+4 Island [LTR:*]
+4 Swamp [LTR:*]
+4 Mountain [LTR:*]
+4 Forest [LTR:*]
+4 Plains [LTR:*] [foil]
+4 Island [LTR:*] [foil]
+4 Swamp [LTR:*] [foil]
+4 Mountain [LTR:*] [foil]
+4 Forest [LTR:*] [foil]

--- a/data/bundle-land-pack/mom/March of the Machine Bundle Land Pack.txt
+++ b/data/bundle-land-pack/mom/March of the Machine Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: March of the Machine Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/march-of-the-machine
+// DATE: 2023-04-21
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish. The bundle uses the regular default-frame basics
+// (the set's full-art lands are booster-only), so [MOM:*] round-robins those.
+4 Plains [MOM:*]
+4 Island [MOM:*]
+4 Swamp [MOM:*]
+4 Mountain [MOM:*]
+4 Forest [MOM:*]
+4 Plains [MOM:*] [foil]
+4 Island [MOM:*] [foil]
+4 Swamp [MOM:*] [foil]
+4 Mountain [MOM:*] [foil]
+4 Forest [MOM:*] [foil]

--- a/data/bundle-land-pack/neo/Kamigawa- Neon Dynasty Bundle Land Pack.txt
+++ b/data/bundle-land-pack/neo/Kamigawa- Neon Dynasty Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Kamigawa: Neon Dynasty Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/kamigawa-neon-dynasty
+// DATE: 2022-02-18
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish. The bundle uses the regular default-frame basics
+// (the set's full-art lands are booster-only), so [NEO:*] round-robins those.
+4 Plains [NEO:*]
+4 Island [NEO:*]
+4 Swamp [NEO:*]
+4 Mountain [NEO:*]
+4 Forest [NEO:*]
+4 Plains [NEO:*] [foil]
+4 Island [NEO:*] [foil]
+4 Swamp [NEO:*] [foil]
+4 Mountain [NEO:*] [foil]
+4 Forest [NEO:*] [foil]

--- a/data/bundle-land-pack/one/Phyrexia- All Will Be One Bundle Land Pack.txt
+++ b/data/bundle-land-pack/one/Phyrexia- All Will Be One Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Phyrexia: All Will Be One Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/phyrexia-all-will-be-one
+// DATE: 2023-02-10
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish. The bundle uses the regular default-frame basics
+// (the set's full-art lands are booster-only), so [ONE:*] round-robins those.
+4 Plains [ONE:*]
+4 Island [ONE:*]
+4 Swamp [ONE:*]
+4 Mountain [ONE:*]
+4 Forest [ONE:*]
+4 Plains [ONE:*] [foil]
+4 Island [ONE:*] [foil]
+4 Swamp [ONE:*] [foil]
+4 Mountain [ONE:*] [foil]
+4 Forest [ONE:*] [foil]

--- a/data/bundle-land-pack/sos/Secrets of Strixhaven Bundle Land Pack.txt
+++ b/data/bundle-land-pack/sos/Secrets of Strixhaven Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Secrets of Strixhaven Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/secrets-of-strixhaven
+// DATE: 2026-04-24
+// Bundle land pack: 30 basic lands, 15 traditional foil + 15 non-foil,
+// 3 of each type per finish. The bundle uses the regular default-frame basics
+// (the set's full-art lands are booster-only), so [SOS:*] round-robins those.
+3 Plains [SOS:*]
+3 Island [SOS:*]
+3 Swamp [SOS:*]
+3 Mountain [SOS:*]
+3 Forest [SOS:*]
+3 Plains [SOS:*] [foil]
+3 Island [SOS:*] [foil]
+3 Swamp [SOS:*] [foil]
+3 Mountain [SOS:*] [foil]
+3 Forest [SOS:*] [foil]

--- a/data/bundle-land-pack/woe/Wilds of Eldraine Bundle Land Pack.txt
+++ b/data/bundle-land-pack/woe/Wilds of Eldraine Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Wilds of Eldraine Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/wilds-of-eldraine
+// DATE: 2023-09-08
+// Bundle land pack: 40 basic lands, 20 traditional foil + 20 non-foil,
+// 4 of each type per finish. The bundle uses the regular default-frame basics
+// (the set's full-art lands are booster-only), so [WOE:*] round-robins those.
+4 Plains [WOE:*]
+4 Island [WOE:*]
+4 Swamp [WOE:*]
+4 Mountain [WOE:*]
+4 Forest [WOE:*]
+4 Plains [WOE:*] [foil]
+4 Island [WOE:*] [foil]
+4 Swamp [WOE:*] [foil]
+4 Mountain [WOE:*] [foil]
+4 Forest [WOE:*] [foil]


### PR DESCRIPTION
Adds bundle land packs for six sets that are often assumed to use full-art basics but whose **bundles actually ship the regular default-frame basics** — the full-art treatments (NEO ukiyo-e, LTR map lands, MOM harbinger, ONE panorama/phyrexianized, WOE fairy-tale, SOS spellcraft) are booster-exclusive. Confirmed per set from the official collecting/product-overview articles.

- **NEO, LTR, MOM, ONE, WOE** — 40 lands (20 traditional foil + 20 non-foil)
- **SOS** — 30 lands (15 foil + 15 non-foil)

Each uses the `[SET:*]` round-robin (resolves to the default printings). 30 and 40 are already valid `bundle-land-pack` sizes, so no deck-type change.

Paired with a mtg-sealed-content PR linking each Bundle's land component to these decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)