### PR TITLE
Add full-art bundle land packs (ZEN, AKH, HOU, ACR, FDN, DFT, DSK, EOE, ECL)

### DIFF
--- a/data/bundle-land-pack/acr/Assassin's Creed Bundle Land Pack.txt
+++ b/data/bundle-land-pack/acr/Assassin's Creed Bundle Land Pack.txt
@@ -1,0 +1,25 @@
+// NAME: Assassin's Creed Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/assassins-creed
+// DATE: 2024-07-05
+// Bundle land pack: 40 basic lands, all full-art. Listed explicitly
+// because [ACR:*] would resolve to the non-full-art printings.
+2 Plains [ACR:101]
+2 Plains [ACR:102]
+2 Plains [ACR:101] [foil]
+2 Plains [ACR:102] [foil]
+2 Island [ACR:103]
+2 Island [ACR:104]
+2 Island [ACR:103] [foil]
+2 Island [ACR:104] [foil]
+2 Swamp [ACR:105]
+2 Swamp [ACR:106]
+2 Swamp [ACR:105] [foil]
+2 Swamp [ACR:106] [foil]
+2 Mountain [ACR:107]
+2 Mountain [ACR:108]
+2 Mountain [ACR:107] [foil]
+2 Mountain [ACR:108] [foil]
+2 Forest [ACR:109]
+2 Forest [ACR:110]
+2 Forest [ACR:109] [foil]
+2 Forest [ACR:110] [foil]

--- a/data/bundle-land-pack/akh/Amonkhet Bundle Land Pack.txt
+++ b/data/bundle-land-pack/akh/Amonkhet Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Amonkhet Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/amonkhet
+// DATE: 2017-04-28
+// Bundle land pack: 80 basic lands = 20 full-art + 60 default-frame.
+// Full-art printings listed explicitly; default-frame via [AKH:*] round-robin
+// (which resolves to the non-full-art printings).
+12 Plains [AKH:*]
+4 Plains [AKH:250]
+12 Island [AKH:*]
+4 Island [AKH:251]
+12 Swamp [AKH:*]
+4 Swamp [AKH:252]
+12 Mountain [AKH:*]
+4 Mountain [AKH:253]
+12 Forest [AKH:*]
+4 Forest [AKH:254]

--- a/data/bundle-land-pack/dft/Aetherdrift Bundle Land Pack.txt
+++ b/data/bundle-land-pack/dft/Aetherdrift Bundle Land Pack.txt
@@ -1,0 +1,26 @@
+// NAME: Aetherdrift Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/aetherdrift
+// DATE: 2025-02-14
+// Bundle land pack: 40 basic lands = 10 full-art + 30 default-frame.
+// Full-art printings listed explicitly; default-frame via [DFT:*] round-robin
+// (which resolves to the non-full-art printings).
+3 Plains [DFT:*]
+3 Plains [DFT:*] [foil]
+1 Plains [DFT:272]
+1 Plains [DFT:272] [foil]
+3 Island [DFT:*]
+3 Island [DFT:*] [foil]
+1 Island [DFT:273]
+1 Island [DFT:273] [foil]
+3 Swamp [DFT:*]
+3 Swamp [DFT:*] [foil]
+1 Swamp [DFT:274]
+1 Swamp [DFT:274] [foil]
+3 Mountain [DFT:*]
+3 Mountain [DFT:*] [foil]
+1 Mountain [DFT:275]
+1 Mountain [DFT:275] [foil]
+3 Forest [DFT:*]
+3 Forest [DFT:*] [foil]
+1 Forest [DFT:276]
+1 Forest [DFT:276] [foil]

--- a/data/bundle-land-pack/dsk/Duskmourn- House of Horror Bundle Land Pack.txt
+++ b/data/bundle-land-pack/dsk/Duskmourn- House of Horror Bundle Land Pack.txt
@@ -1,0 +1,26 @@
+// NAME: Duskmourn: House of Horror Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/duskmourn-house-of-horror
+// DATE: 2024-09-27
+// Bundle land pack: 30 basic lands = 10 full-art + 20 default-frame.
+// Full-art printings listed explicitly; default-frame via [DSK:*] round-robin
+// (which resolves to the non-full-art printings).
+2 Plains [DSK:*]
+2 Plains [DSK:*] [foil]
+1 Plains [DSK:272]
+1 Plains [DSK:272] [foil]
+2 Island [DSK:*]
+2 Island [DSK:*] [foil]
+1 Island [DSK:273]
+1 Island [DSK:273] [foil]
+2 Swamp [DSK:*]
+2 Swamp [DSK:*] [foil]
+1 Swamp [DSK:274]
+1 Swamp [DSK:274] [foil]
+2 Mountain [DSK:*]
+2 Mountain [DSK:*] [foil]
+1 Mountain [DSK:275]
+1 Mountain [DSK:275] [foil]
+2 Forest [DSK:*]
+2 Forest [DSK:*] [foil]
+1 Forest [DSK:276]
+1 Forest [DSK:276] [foil]

--- a/data/bundle-land-pack/ecl/Lorwyn Eclipsed Bundle Land Pack.txt
+++ b/data/bundle-land-pack/ecl/Lorwyn Eclipsed Bundle Land Pack.txt
@@ -1,0 +1,26 @@
+// NAME: Lorwyn Eclipsed Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/lorwyn-eclipsed
+// DATE: 2026-01-23
+// Bundle land pack: 30 basic lands = 10 full-art + 20 default-frame.
+// Full-art printings listed explicitly; default-frame via [ECL:*] round-robin
+// (which resolves to the non-full-art printings).
+2 Plains [ECL:*]
+2 Plains [ECL:*] [foil]
+1 Plains [ECL:274]
+1 Plains [ECL:274] [foil]
+2 Island [ECL:*]
+2 Island [ECL:*] [foil]
+1 Island [ECL:275]
+1 Island [ECL:275] [foil]
+2 Swamp [ECL:*]
+2 Swamp [ECL:*] [foil]
+1 Swamp [ECL:276]
+1 Swamp [ECL:276] [foil]
+2 Mountain [ECL:*]
+2 Mountain [ECL:*] [foil]
+1 Mountain [ECL:277]
+1 Mountain [ECL:277] [foil]
+2 Forest [ECL:*]
+2 Forest [ECL:*] [foil]
+1 Forest [ECL:278]
+1 Forest [ECL:278] [foil]

--- a/data/bundle-land-pack/eoe/Edge of Eternities Bundle Land Pack.txt
+++ b/data/bundle-land-pack/eoe/Edge of Eternities Bundle Land Pack.txt
@@ -1,0 +1,26 @@
+// NAME: Edge of Eternities Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/edge-of-eternities
+// DATE: 2025-08-01
+// Bundle land pack: 30 basic lands = 10 full-art + 20 default-frame.
+// Full-art printings listed explicitly; default-frame via [EOE:*] round-robin
+// (which resolves to the non-full-art printings).
+2 Plains [EOE:*]
+2 Plains [EOE:*] [foil]
+1 Plains [EOE:262]
+1 Plains [EOE:262] [foil]
+2 Island [EOE:*]
+2 Island [EOE:*] [foil]
+1 Island [EOE:263]
+1 Island [EOE:263] [foil]
+2 Swamp [EOE:*]
+2 Swamp [EOE:*] [foil]
+1 Swamp [EOE:264]
+1 Swamp [EOE:264] [foil]
+2 Mountain [EOE:*]
+2 Mountain [EOE:*] [foil]
+1 Mountain [EOE:265]
+1 Mountain [EOE:265] [foil]
+2 Forest [EOE:*]
+2 Forest [EOE:*] [foil]
+1 Forest [EOE:266]
+1 Forest [EOE:266] [foil]

--- a/data/bundle-land-pack/fdn/Foundations Bundle Land Pack.txt
+++ b/data/bundle-land-pack/fdn/Foundations Bundle Land Pack.txt
@@ -1,0 +1,36 @@
+// NAME: Foundations Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/foundations
+// DATE: 2024-11-15
+// Bundle land pack: 40 basic lands = 20 full-art + 20 default-frame.
+// Full-art printings listed explicitly; default-frame via [FDN:*] round-robin
+// (which resolves to the non-full-art printings).
+2 Plains [FDN:*]
+2 Plains [FDN:*] [foil]
+1 Plains [FDN:282]
+1 Plains [FDN:283]
+1 Plains [FDN:282] [foil]
+1 Plains [FDN:283] [foil]
+2 Island [FDN:*]
+2 Island [FDN:*] [foil]
+1 Island [FDN:284]
+1 Island [FDN:285]
+1 Island [FDN:284] [foil]
+1 Island [FDN:285] [foil]
+2 Swamp [FDN:*]
+2 Swamp [FDN:*] [foil]
+1 Swamp [FDN:286]
+1 Swamp [FDN:287]
+1 Swamp [FDN:286] [foil]
+1 Swamp [FDN:287] [foil]
+2 Mountain [FDN:*]
+2 Mountain [FDN:*] [foil]
+1 Mountain [FDN:288]
+1 Mountain [FDN:289]
+1 Mountain [FDN:288] [foil]
+1 Mountain [FDN:289] [foil]
+2 Forest [FDN:*]
+2 Forest [FDN:*] [foil]
+1 Forest [FDN:290]
+1 Forest [FDN:291]
+1 Forest [FDN:290] [foil]
+1 Forest [FDN:291] [foil]

--- a/data/bundle-land-pack/hou/Hour of Devastation Bundle Land Pack.txt
+++ b/data/bundle-land-pack/hou/Hour of Devastation Bundle Land Pack.txt
@@ -1,0 +1,16 @@
+// NAME: Hour of Devastation Bundle Land Pack
+// SOURCE: https://magic.wizards.com/en/products/hour-of-devastation
+// DATE: 2017-07-14
+// Bundle land pack: 80 basic lands = 20 full-art + 60 default-frame.
+// Full-art printings listed explicitly; default-frame via [HOU:*] round-robin
+// (which resolves to the non-full-art printings).
+12 Plains [HOU:*]
+4 Plains [HOU:185]
+12 Island [HOU:*]
+4 Island [HOU:186]
+12 Swamp [HOU:*]
+4 Swamp [HOU:187]
+12 Mountain [HOU:*]
+4 Mountain [HOU:188]
+12 Forest [HOU:*]
+4 Forest [HOU:189]

--- a/data/bundle-land-pack/zen/Zendikar Fat Pack Land Pack.txt
+++ b/data/bundle-land-pack/zen/Zendikar Fat Pack Land Pack.txt
@@ -1,0 +1,25 @@
+// NAME: Zendikar Fat Pack Land Pack
+// SOURCE: https://magic.wizards.com/en/products/zendikar
+// DATE: 2009-10-02
+// Fat Pack land pack: 40 basic lands, all full-art. Listed explicitly
+// because [ZEN:*] would resolve to the non-full-art printings.
+2 Plains [ZEN:230]
+2 Plains [ZEN:231]
+2 Plains [ZEN:232]
+2 Plains [ZEN:233]
+2 Island [ZEN:234]
+2 Island [ZEN:235]
+2 Island [ZEN:236]
+2 Island [ZEN:237]
+2 Swamp [ZEN:238]
+2 Swamp [ZEN:239]
+2 Swamp [ZEN:240]
+2 Swamp [ZEN:241]
+2 Mountain [ZEN:242]
+2 Mountain [ZEN:243]
+2 Mountain [ZEN:244]
+2 Mountain [ZEN:245]
+2 Forest [ZEN:246]
+2 Forest [ZEN:247]
+2 Forest [ZEN:248]
+2 Forest [ZEN:249]

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -78,7 +78,7 @@ bundle-land-pack:
   name: "Bundle Land Pack"
   sections:
     # 75 = Guilds of Ravnica / Ravnica Allegiance bundle (70 non-foil + 5 foil)
-    Main Deck: [30, 32, 40, 75]
+    Main Deck: [15, 20, 30, 32, 40, 70, 75, 80]
 challenge:
   category: "deck"
   format: null


### PR DESCRIPTION
Adds bundle/fat-pack land packs for nine sets whose packs contain the set's **full-art** basics — confirmed per set via a research pass over the official collecting/product-overview articles (distinguishing "the set features full-art lands" from "the bundle's land pack actually contains them").

Full-art printings are listed with **explicit collector numbers** (since `[SET:*]` resolves to the *non*-full-art printings); where a pack mixes full-art with default-frame basics, the default portion uses the `[SET:*]` round-robin.

| Set | total | composition |
|---|---|---|
| ZEN | 40 NF | all full-art |
| ACR | 40 | all full-art (20F+20N) |
| AKH, HOU | 80 NF | 20 full-art + 60 default |
| FDN | 40 | 20 full-art + 20 default |
| DFT | 40 | 10 full-art + 30 default |
| DSK, EOE, ECL | 30 | 10 full-art + 20 default |

Treatment disambiguation against the card index:
- **DFT** uses the plain "Driver's Seat" full-art (#272-276), **not** the Finish Line box-toppers (`firstplacefoil`).
- **EOE** uses the plain borderless celestial (#262-266), **not** the galaxy-foil booster premium.

Adds `20` and `80` to the `bundle-land-pack` sizes (overlaps #280/#283 on that line; union is `[15, 20, 30, 32, 40, 80]`).

Validated: all nine parse with the correct totals and foil splits; explicit numbers and round-robin targets confirmed against the index.

Paired with a mtg-sealed-content PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)