### PR TITLE
Add core set fat pack land packs (M12, M13, M14, M15, ORI)

### DIFF
--- a/data/bundle-land-pack/m12/Magic 2012 Fat Pack Land Pack.txt
+++ b/data/bundle-land-pack/m12/Magic 2012 Fat Pack Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Magic 2012 Fat Pack Land Pack
+// SOURCE: https://magic.wizards.com/en/products/magic-2012
+// DATE: 2011-07-15
+// Fat Pack land pack: 80 non-foil basic lands from the set, 16 of each type
+// (the pre-2019 fat packs shipped 80 basics). Default-frame basics, so
+// [M12:*] round-robins the set's printings.
+16 Plains [M12:*]
+16 Island [M12:*]
+16 Swamp [M12:*]
+16 Mountain [M12:*]
+16 Forest [M12:*]

--- a/data/bundle-land-pack/m13/Magic 2013 Fat Pack Land Pack.txt
+++ b/data/bundle-land-pack/m13/Magic 2013 Fat Pack Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Magic 2013 Fat Pack Land Pack
+// SOURCE: https://magic.wizards.com/en/products/magic-2013
+// DATE: 2012-07-13
+// Fat Pack land pack: 80 non-foil basic lands from the set, 16 of each type
+// (the pre-2019 fat packs shipped 80 basics). Default-frame basics, so
+// [M13:*] round-robins the set's printings.
+16 Plains [M13:*]
+16 Island [M13:*]
+16 Swamp [M13:*]
+16 Mountain [M13:*]
+16 Forest [M13:*]

--- a/data/bundle-land-pack/m14/Magic 2014 Fat Pack Land Pack.txt
+++ b/data/bundle-land-pack/m14/Magic 2014 Fat Pack Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Magic 2014 Fat Pack Land Pack
+// SOURCE: https://magic.wizards.com/en/products/magic-2014
+// DATE: 2013-07-19
+// Fat Pack land pack: 80 non-foil basic lands from the set, 16 of each type
+// (the pre-2019 fat packs shipped 80 basics). Default-frame basics, so
+// [M14:*] round-robins the set's printings.
+16 Plains [M14:*]
+16 Island [M14:*]
+16 Swamp [M14:*]
+16 Mountain [M14:*]
+16 Forest [M14:*]

--- a/data/bundle-land-pack/m15/Magic 2015 Fat Pack Land Pack.txt
+++ b/data/bundle-land-pack/m15/Magic 2015 Fat Pack Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Magic 2015 Fat Pack Land Pack
+// SOURCE: https://magic.wizards.com/en/products/magic-2015
+// DATE: 2014-07-18
+// Fat Pack land pack: 80 non-foil basic lands from the set, 16 of each type
+// (the pre-2019 fat packs shipped 80 basics). Default-frame basics, so
+// [M15:*] round-robins the set's printings.
+16 Plains [M15:*]
+16 Island [M15:*]
+16 Swamp [M15:*]
+16 Mountain [M15:*]
+16 Forest [M15:*]

--- a/data/bundle-land-pack/ori/Magic Origins Fat Pack Land Pack.txt
+++ b/data/bundle-land-pack/ori/Magic Origins Fat Pack Land Pack.txt
@@ -1,0 +1,11 @@
+// NAME: Magic Origins Fat Pack Land Pack
+// SOURCE: https://magic.wizards.com/en/products/magic-origins
+// DATE: 2015-07-17
+// Fat Pack land pack: 80 non-foil basic lands from the set, 16 of each type
+// (the pre-2019 fat packs shipped 80 basics). Default-frame basics, so
+// [ORI:*] round-robins the set's printings.
+16 Plains [ORI:*]
+16 Island [ORI:*]
+16 Swamp [ORI:*]
+16 Mountain [ORI:*]
+16 Forest [ORI:*]

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -78,7 +78,7 @@ bundle-land-pack:
   name: "Bundle Land Pack"
   sections:
     # 75 = Guilds of Ravnica / Ravnica Allegiance bundle (70 non-foil + 5 foil)
-    Main Deck: [30, 32, 40, 75]
+    Main Deck: [15, 20, 30, 32, 40, 70, 75, 80]
 challenge:
   category: "deck"
   format: null


### PR DESCRIPTION
Adds fat pack land packs for the 2011-2015 core sets, each **80 non-foil basic lands** (16 of each type) per the pre-2019 fat-pack standard. All default-frame basics, so each uses the `[SET:*]` round-robin.

(M10/M11 already have 40-card packs in the repo; M12-M15 and ORI use 80.)

Adds `20` and `80` to the `bundle-land-pack` sizes (overlaps #280/#283/#285 on that line; union is `[15, 20, 30, 32, 40, 80]`).

Paired with a mtg-sealed-content PR linking each Fat Pack's land component to these decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)