### PR TITLE
GRN, RNA: correct bundle land packs to 75 lands (5 foil)

### DIFF
--- a/data/bundle-land-pack/grn/Guilds of Ravnica Bundle Land Pack.txt
+++ b/data/bundle-land-pack/grn/Guilds of Ravnica Bundle Land Pack.txt
@@ -1,13 +1,15 @@
 // NAME: Guilds of Ravnica Bundle Land Pack
 // SOURCE: https://mtg.wiki/page/Guilds_of_Ravnica
 // DATE: 2018-10-05
-4 Plains [GRN:260]
-4 Plains [GRN:260] [foil]
-4 Island [GRN:261]
-4 Island [GRN:261] [foil]
-4 Swamp [GRN:262]
-4 Swamp [GRN:262] [foil]
-4 Mountain [GRN:263]
-4 Mountain [GRN:263] [foil]
-4 Forest [GRN:264]
-4 Forest [GRN:264] [foil]
+// Bundle land pack: 75 basic lands, 5 of them traditional foil (70 non-foil +
+// 5 foil, i.e. 14 non-foil + 1 foil of each type). Single default art per type.
+14 Plains [GRN:260]
+1 Plains [GRN:260] [foil]
+14 Island [GRN:261]
+1 Island [GRN:261] [foil]
+14 Swamp [GRN:262]
+1 Swamp [GRN:262] [foil]
+14 Mountain [GRN:263]
+1 Mountain [GRN:263] [foil]
+14 Forest [GRN:264]
+1 Forest [GRN:264] [foil]

--- a/data/bundle-land-pack/rna/Ravnica Allegiance Bundle Land Pack.txt
+++ b/data/bundle-land-pack/rna/Ravnica Allegiance Bundle Land Pack.txt
@@ -1,13 +1,15 @@
 // NAME: Ravnica Allegiance Bundle Land Pack
 // SOURCE: https://mtg.wiki/page/Ravnica_Allegiance
 // DATE: 2019-01-25
-4 Plains [RNA:260]
-4 Plains [RNA:260] [foil]
-4 Island [RNA:261]
-4 Island [RNA:261] [foil]
-4 Swamp [RNA:262]
-4 Swamp [RNA:262] [foil]
-4 Mountain [RNA:263]
-4 Mountain [RNA:263] [foil]
-4 Forest [RNA:264]
-4 Forest [RNA:264] [foil]
+// Bundle land pack: 75 basic lands, 5 of them traditional foil (70 non-foil +
+// 5 foil, i.e. 14 non-foil + 1 foil of each type). Single default art per type.
+14 Plains [RNA:260]
+1 Plains [RNA:260] [foil]
+14 Island [RNA:261]
+1 Island [RNA:261] [foil]
+14 Swamp [RNA:262]
+1 Swamp [RNA:262] [foil]
+14 Mountain [RNA:263]
+1 Mountain [RNA:263] [foil]
+14 Forest [RNA:264]
+1 Forest [RNA:264] [foil]

--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -77,7 +77,8 @@ bundle-land-pack:
   format: null
   name: "Bundle Land Pack"
   sections:
-    Main Deck: [30, 32, 40]
+    # 75 = Guilds of Ravnica / Ravnica Allegiance bundle (70 non-foil + 5 foil)
+    Main Deck: [30, 32, 40, 75]
 challenge:
   category: "deck"
   format: null


### PR DESCRIPTION
The Guilds of Ravnica and Ravnica Allegiance bundles each held **75 basic lands, only 5 of them traditional foil** (70 non-foil + 5 foil = 14 non-foil + 1 foil per type) — not the 40 (20 foil + 20 non-foil) previously in the repo.

Rewrites both decks to 75/5 and adds `75` to the `bundle-land-pack` allowed sizes.

No sealed-content change needed — the deck names are unchanged, and the bundles already reference them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)