### PR TITLE
dbtk: pin Ravnica Allegiance toolkit guildgates to their printings

### DIFF
--- a/data/dbtk/rna/Deck Builder's Toolkit.txt
+++ b/data/dbtk/rna/Deck Builder's Toolkit.txt
@@ -100,16 +100,26 @@
 1 Rakdos Locket
 1 Selesnya Locket [GRN]
 1 Simic Locket
-2 Azorius Guildgate
-2 Dimir Guildgate [GRN]
-2 Rakdos Guildgate
-2 Gruul Guildgate
-2 Selesnya Guildgate [GRN]
-2 Orzhov Guildgate
-2 Izzet Guildgate [GRN]
-2 Golgari Guildgate [GRN]
-2 Boros Guildgate [GRN]
-2 Simic Guildgate
+1 Azorius Guildgate [RNA:243]
+1 Azorius Guildgate [RNA:244]
+1 Dimir Guildgate [GRN:245]
+1 Dimir Guildgate [GRN:246]
+1 Rakdos Guildgate [RNA:255]
+1 Rakdos Guildgate [RNA:256]
+1 Gruul Guildgate [RNA:249]
+1 Gruul Guildgate [RNA:250]
+1 Selesnya Guildgate [GRN:255]
+1 Selesnya Guildgate [GRN:256]
+1 Orzhov Guildgate [RNA:252]
+1 Orzhov Guildgate [RNA:253]
+1 Izzet Guildgate [GRN:251]
+1 Izzet Guildgate [GRN:252]
+1 Golgari Guildgate [GRN:248]
+1 Golgari Guildgate [GRN:249]
+1 Boros Guildgate [GRN:243]
+1 Boros Guildgate [GRN:244]
+1 Simic Guildgate [RNA:257]
+1 Simic Guildgate [RNA:258]
 20 Plains [RNA:*]
 20 Island [RNA:*]
 20 Swamp [RNA:*]


### PR DESCRIPTION
The Ravnica Allegiance Deck Builder's Toolkit listed its guildgates under-specified:

```
2 Azorius Guildgate          # bare — resolves to the RTR/Dragon's Maze printing, not RNA
2 Dimir Guildgate [GRN]      # set only — both copies collapse onto one art
```

Guildgates were printed in the Return to Ravnica block (2012–2013) as well, so the untagged Ravnica Allegiance-guild gates resolved to their **oldest** printing rather than RNA, and the `[GRN]`-only gates picked a single art for both copies.

This pins each gate to its two distinct full-art printings by collector number — RNA guilds (Azorius, Gruul, Orzhov, Rakdos, Simic) → `RNA`, GRN guilds (Boros, Dimir, Golgari, Izzet, Selesnya) → `GRN`:

```
1 Azorius Guildgate [RNA:243]
1 Azorius Guildgate [RNA:244]
...
1 Simic Guildgate [RNA:258]
```

Count is unchanged (2 per guild, 20 gates, deck total 225). **All 20 printings verified present in the card index** (numbers cross-checked against Scryfall and `index/index.json`).