### PR TITLE
Add 90 to bundle-land-pack sizes (MSH Draft Night)

### DIFF
--- a/lib/deck_types.yaml
+++ b/lib/deck_types.yaml
@@ -78,7 +78,8 @@ bundle-land-pack:
   name: "Bundle Land Pack"
   sections:
     # 75 = Guilds of Ravnica / Ravnica Allegiance bundle (70 non-foil + 5 foil)
-    Main Deck: [15, 20, 30, 32, 40, 70, 75, 80]
+    # 90 = Marvel Super Heroes Draft Night land pack (18 of each type)
+    Main Deck: [15, 20, 30, 32, 40, 70, 75, 80, 90]
 challenge:
   category: "deck"
   format: null


### PR DESCRIPTION
The **Marvel Super Heroes Draft Night** land pack (merged in #281) is a 90-card `bundle-land-pack` (18 basics of each type), but `90` was never added to the deck type's allowed `Main Deck` sizes — so `bin/build_jsons` fails validation on it:

> ... Draft Night Land Pack.txt of type Bundle Land Pack section Main Deck has invalid size 90

This adds `90`, making the size list `[15, 20, 30, 32, 40, 70, 75, 80, 90]`. Verified the Draft Night deck validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)