### PR TITLE
sld: add the Wild in Bloom decklist

### DIFF
--- a/data/sld/sld/Wild in Bloom.txt
+++ b/data/sld/sld/Wild in Bloom.txt
@@ -1,0 +1,8 @@
+// NAME: Wild in Bloom
+// SOURCE: https://mtg.wiki/page/Secret_Lair_Drop_Series:_Wild_in_Bloom
+// DATE: 2026-07-13
+1 [SLD:2658] Nissa, Resurgent Animist [foil]
+1 [SLD:2659] Ramunap Excavator [foil]
+1 [SLD:2660] Six [foil]
+1 [SLD:2661] Tireless Provisioner [foil]
+1 [SLD:2662] Titania, Protector of Argoth [foil]


### PR DESCRIPTION
Adds the decklist for the **Secret Lair Drop Series: Wild in Bloom** drop (released 2026-07-13, a MagicCon Festival in a Box exclusive).

It's a **5-card, foil-only** drop (`SLD #2658–2662`):

```
1 [SLD:2658] Nissa, Resurgent Animist [foil]
1 [SLD:2659] Ramunap Excavator [foil]
1 [SLD:2660] Six [foil]
1 [SLD:2661] Tireless Provisioner [foil]
1 [SLD:2662] Titania, Protector of Argoth [foil]
```

All five exist only in traditional foil (no non-foil printing), so each carries `[foil]` per the foil-only-drop convention (cf. *A Devastation of Dragons*). Names, collector numbers and foil-only finish verified against Scryfall.