### PR TITLE
Add The Hobbit Welcome Decks (5 monocolor 40-card decks)

### DIFF
--- a/data/welcome/hob/Black Deck.txt
+++ b/data/welcome/hob/Black Deck.txt
@@ -1,0 +1,25 @@
+// NAME: Black Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks
+// DATE: 2026-08-14
+2 Front Porch Sentries
+1 Great Fierce Bee
+1 Stir Up Trouble
+1 Haunt of the Dead Marshes [HOC:186]
+1 Desolation Prowler
+1 Ravening Warg
+2 Gollum, Silent Slinker
+2 Bilbo's Deadly Slice
+1 Dreaded Bat-Cloud
+1 Rogue's Passage [HOC:212]
+1 Crude Bent Blade
+1 Languish [HOC:187]
+1 Shadow of the Enemy [HOC:190]
+1 Gollum the Abandoned
+1 Gnashing of Teeth
+1 Troll of Khazad-dûm [HOC:191]
+1 Merciless Executioner [HOC:188]
+1 Bitter Downfall [HOC:185]
+1 Reverent Howl
+1 Night's Whisper [HOC:189]
+1 Stony-Voiced Goblins
+16 Swamp [HOB:191]

--- a/data/welcome/hob/Blue Deck.txt
+++ b/data/welcome/hob/Blue Deck.txt
@@ -1,0 +1,24 @@
+// NAME: Blue Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks
+// DATE: 2026-08-14
+2 Bilbo Baggins, Burglar
+16 Island [HOB:190]
+1 Pelargir Survivor [HOC:182]
+2 Lakeshore Apothecary
+1 Confusticate and Bebother
+1 Ravenhill Flock
+1 Lórien Revealed [HOC:179]
+1 Thranduil's Decree
+1 Knights of Dol Amroth [HOC:178]
+1 Grey Havens Navigator [HOC:175]
+1 Rogue's Passage [HOC:212]
+2 Ithilien Kingfisher [HOC:177]
+1 Hithlain Knots [HOC:176]
+1 Captain of Umbar [HOC:173]
+1 Minas Tirith Garrison [HOC:180]
+1 Colossal Whale [HOC:174]
+1 Willow-Wind [HOC:184]
+1 Bilbo, Luckwearer
+2 Uneasy Partings
+1 Nimrodel Watcher [HOC:181]
+1 Stern Scolding [HOC:183]

--- a/data/welcome/hob/Green Deck.txt
+++ b/data/welcome/hob/Green Deck.txt
@@ -1,0 +1,23 @@
+// NAME: Green Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks
+// DATE: 2026-08-14
+16 Forest [HOB:193]
+2 Guardian of the Halls
+2 Quarrel
+2 Galadhrim Guide [HOC:207]
+1 Galion, Elvenking's Butler
+1 Elvish Visionary [HOC:206]
+1 Warg Tactics
+1 Beorn's Hospitality
+1 Rogue's Passage [HOC:212]
+1 Mirkwood Elk [HOC:210]
+1 Celeborn the Wise [HOC:203]
+1 Gift of Strands [HOC:208]
+1 Elvish Archdruid [HOC:204]
+1 Lothlórien Lookout [HOC:209]
+1 Woodland Weavemaster
+1 Mirkwood Pathmaker
+1 Beorn, Reluctant Host
+2 Wood Elves
+2 Elvish Mystic [HOC:205]
+1 Attercop

--- a/data/welcome/hob/Red Deck.txt
+++ b/data/welcome/hob/Red Deck.txt
@@ -1,0 +1,21 @@
+// NAME: Red Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks
+// DATE: 2026-08-14
+16 Mountain [HOB:192]
+2 Wayfarer's Bauble [HOC:211]
+2 Battle-Scarred Goblin [HOC:192]
+1 Improvised Club [HOC:197]
+2 Smaug, the Great Calamity
+2 Olog-hai Crusher [HOC:200]
+1 Gandalf, Spark Starter
+2 Ragged Short Spear
+2 Smite the Deathless [HOC:202]
+2 Goblin Fireleaper [HOC:195]
+1 Oliphaunt [HOC:199]
+1 Rogue's Passage [HOC:212]
+1 Goblin Cratermaker [HOC:194]
+1 Inferno Titan [HOC:198]
+1 Guttersnipe [HOC:196]
+1 Orcish Siegemaster [HOC:201]
+1 Snowslope Hunter
+1 Fire of Orthanc [HOC:193]

--- a/data/welcome/hob/White Deck.txt
+++ b/data/welcome/hob/White Deck.txt
@@ -1,0 +1,23 @@
+// NAME: White Deck
+// SOURCE: https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks
+// DATE: 2026-08-14
+1 Bofur, Reliable Guardian
+16 Plains [HOB:189]
+2 Dwarven Provisioner
+1 Velvetwing Butterflies
+2 Magnificent End
+1 Mentor of the Meek [HOC:170]
+1 Fiend Hunter [HOC:167]
+2 Errand-Rider of Gondor [HOC:165]
+1 Landroval, Horizon Witness [HOC:169]
+1 Rogue's Passage [HOC:212]
+2 Soldier of the Grey Host [HOC:171]
+1 Eagles of the North [HOC:164]
+1 Dúnedain Blade [HOC:163]
+1 Fog on the Barrow-Downs [HOC:168]
+1 Eagle of the Great Shelf
+1 Banishing Light [HOC:161]
+1 Dawn of a New Age [HOC:162]
+1 Vow to Erebor
+2 Westfold Rider [HOC:172]
+1 Esquire of the King [HOC:166]


### PR DESCRIPTION
The five Hobbit Welcome Decks from the [official announcement](https://magic.wizards.com/en/news/announcements/the-hobbit-welcome-decks) — monocolor 40-card decks mixing The Hobbit (HOB) with Eternal-legal reprints (HOC), at `data/welcome/hob/`.

Resolution notes:
- The HOC printings are the welcome-deck block, which forms contiguous per-color collector runs (White 161–172, Blue 173–184, Black 185–191, Red 192–202, Green 203–210, shared Rogue's Passage/lands 211–212) — a strong structural check that every cross-set ref is right. (Cards with multiple HOC printings, e.g. Dawn of a New Age 13/53/162, use the block version.)
- Basics pinned to the HOB default printings (189–193).
- The announcement lists Olog-hai Crusher as two separate 1x lines in Red; merged to 2x.

All five decks total exactly 40 cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)